### PR TITLE
Improving cluster auto-discovery

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -121,10 +121,8 @@ default["percona"]["backup"]["password"]                        = "123-changeme"
 # XtraDB Cluster Settings
 default["percona"]["cluster"]["binlog_format"]                  = "ROW"
 default["percona"]["cluster"]["wsrep_provider"]                 = "/usr/lib64/libgalera_smm.so"
-default["percona"]["cluster"]["wsrep_cluster_address"]          = ""
 default["percona"]["cluster"]["wsrep_slave_threads"]            = 2
-default["percona"]["cluster"]["wsrep_cluster_name"]             = ""
+default["percona"]["cluster"]["wsrep_cluster_name"]             = "default"
 default["percona"]["cluster"]["wsrep_sst_method"]               = "rsync"
-default["percona"]["cluster"]["wsrep_node_name"]                = ""
 default["percona"]["cluster"]["innodb_locks_unsafe_for_binlog"] = 1
 default["percona"]["cluster"]["innodb_autoinc_lock_mode"]       = 2

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -2,13 +2,8 @@ include_recipe "percona::default"
 
 # install packages
 package "percona-xtradb-cluster-server-5.5" do
+  action :install
   options "--force-yes"
-end
-
-# define the service
-service "mysql" do
-  supports :restart => true
-  action [:enable, :start]
 end
 
 percona = node["percona"]
@@ -21,6 +16,14 @@ passwords = EncryptedPasswords.new(node, percona["encrypted_data_bag"])
 
 datadir = mysqld["datadir"] || server["datadir"]
 user    = mysqld["user"] || server["user"]
+
+cluster_nodes = search(:node, "chef_environment:#{node.chef_environment} AND percona_cluster_wsrep_cluster_name:#{node["percona"]["cluster"]["wsrep_cluster_name"]} NOT hostname:#{node["hostname"]}")
+
+if related_node = cluster_nodes.first
+  cluster_address = related_node["ipaddress"]
+else
+  cluster_address = ""
+end
 
 # now let's set the root password only if this is the initial install
 execute "Update MySQL root password" do
@@ -44,11 +47,12 @@ end
 
 # setup the main server config file
 template "/etc/my.cnf" do
-  source "my.cnf.#{conf ? "custom" : server["role"]}.erb"
+  source "my.cnf.#{conf ? "custom" : "cluster"}.erb"
+  variables(:cluster_address => cluster_address)
   owner "root"
   group "root"
   mode 0744
-  notifies :restart, resources(:service => "mysql")
+  notifies :restart, "service[mysql]", :immediately
 end
 
 # setup the debian system user config
@@ -58,7 +62,13 @@ template "/etc/mysql/debian.cnf" do
   owner "root"
   group "root"
   mode 0744
-  notifies :restart, resources(:service => "mysql")
+  notifies :restart, "service[mysql]", :immediately
+end
+
+# define the service
+service "mysql" do
+  supports :restart => true
+  action [:enable, :start]
 end
 
 # access grants

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -55,11 +55,10 @@ net_read_timeout = <%= node["percona"]["server"]["net_read_timeout"] %>
 #
 binlog_format                  = <%= node["percona"]["cluster"]["binlog_format"] %>
 wsrep_provider                 = <%= node["percona"]["cluster"]["wsrep_provider"] %>
-wsrep_cluster_address          = <%= node["percona"]["cluster"]["wsrep_cluster_address"] %>
+wsrep_cluster_address          = gcomm://<%= @cluster_address %>
 wsrep_slave_threads            = <%= node["percona"]["cluster"]["wsrep_slave_threads"] %>
 wsrep_cluster_name             = <%= node["percona"]["cluster"]["wsrep_cluster_name"] %>
 wsrep_sst_method               = <%= node["percona"]["cluster"]["wsrep_sst_method"] %>
-wsrep_node_name                = <%= node["percona"]["cluster"]["wsrep_node_name"] %>
 innodb_locks_unsafe_for_binlog = <%= node["percona"]["cluster"]["innodb_locks_unsafe_for_binlog"] %>
 innodb_autoinc_lock_mode       = <%= node["percona"]["cluster"]["innodb_autoinc_lock_mode"] %>
 


### PR DESCRIPTION
This makes it easier to get a Percona Cluster up and running. The recipe
will automatically discover other nodes in the same Chef environment
that have the same cluster name, and configure Galera accordingly.
