### PR TITLE
Piggyback on mysql cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following platforms are supported by this cookbook, meaning that the recipes
 ### Cookbooks
 
 * [apt](http://community.opscode.com/cookbooks/apt) Opscode LWRP Cookbook
+* [mysql](http://community.opscode.com/cookbooks/mysql) Opscode Cookbook
 * [openssl](http://community.opscode.com/cookbooks/openssl) Opscode Cookbook
 
 ## Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -130,3 +130,25 @@ default["percona"]["cluster"]["wsrep_sst_method"]               = "rsync"
 default["percona"]["cluster"]["wsrep_node_name"]                = ""
 default["percona"]["cluster"]["innodb_locks_unsafe_for_binlog"] = 1
 default["percona"]["cluster"]["innodb_autoinc_lock_mode"]       = 2
+
+# Options are: 5.0, 5.1, 5.5, latest
+default['percona']['version'] = "5.5"
+
+normal['mysql']['use_upstart'] = false
+
+case node['platform']
+when "ubuntu", "debian"
+  case node['percona']['version']
+  when "5.0"
+    normal['mysql']['client']['packages'] = %w{percona-sql-client}
+    normal['mysql']['server']['packages'] = %w{percona-sql-server}
+  when "5.1", "5.5"
+    normal['mysql']['client']['packages'] = %W{percona-server-client-#{node['percona']['version']}}
+    normal['mysql']['server']['packages'] = %W{percona-server-server-#{node['percona']['version']}}
+  when "latest"
+    normal['mysql']['client']['packages'] = %w{percona-server-client}
+    normal['mysql']['server']['packages'] = %w{percona-server-server}
+  end
+when "centos", "redhat", "amazon", "scientific", "fedora"
+  # TODO: Add yum support
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ recipe "percona::replication", "Used internally to grant permissions for replica
 recipe "percona::access_grants", "Used internally to grant permissions for recipes"
 
 depends "apt"
-depends "openssl"
+depends "mysql", ">= 1.3.0"
 
 %w[debian ubuntu].each do |os|
   supports os

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -1,5 +1,2 @@
 include_recipe "percona::default"
-
-package "percona-server-client" do
-  options "--force-yes"
-end
+include_recipe "mysql::client"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,10 +1,5 @@
 include_recipe "percona::default"
-
-# install packages
-package "percona-server-server" do
-  action :install
-  options "--force-yes"
-end
+include_recipe "mysql::server"
 
 percona = node["percona"]
 server  = percona["server"]


### PR DESCRIPTION
Opscode has recently made efforts to decouple the mysql cookbook from using specifically mysql, so that it can be used as a dependency for drop-in replacements.

I was working on a cookbook to scratch my own itch, and was wondering whether you'd consider accepting a PR to move your own cookbook in that direction. I'm totally willing to do the legwork :)

Here's my repo:
https://github.com/myplanetdigital/chef-percona
