### PR TITLE
Added attribute to set the main config file path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ when "rhel"
 end
 
 # Cookbook Settings
+default["percona"]["main_config_file"]                          = "/etc/my.cnf"
 default["percona"]["keyserver"]                                 = "keys.gnupg.net"
 default["percona"]["encrypted_data_bag"]                        = "passwords"
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ when "rhel"
 end
 
 # Cookbook Settings
+default["percona"]["main_config_file"]                          = "/etc/my.cnf"
 default["percona"]["keyserver"]                                 = "keys.gnupg.net"
 default["percona"]["encrypted_data_bag"]                        = "passwords"
 

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -28,20 +28,20 @@ service "mysql" do
   action :enable
 end
 
-# setup the main server config file
-template "/etc/my.cnf" do
-  source "my.cnf.#{conf ? "custom" : server["role"]}.erb"
-  owner "root"
-  group "root"
-  mode 0744
-  notifies :restart, "service[mysql]", :immediately
-end
-
 # this is where we dump sql templates for replication, etc.
 directory "/etc/mysql" do
   owner "root"
   group "root"
   mode 0755
+end
+
+# setup the main server config file
+template percona["main_config_file"] do
+  source "my.cnf.#{conf ? "custom" : server["role"]}.erb"
+  owner "root"
+  group "root"
+  mode 0744
+  notifies :restart, "service[mysql]", :immediately
 end
 
 # setup the data directory


### PR DESCRIPTION
For some crazy reason, in Ubuntu 12.04 the percona package install is giving precedence to `/etc/mysql/my.cnf` over `/etc/my.cnf`. Not sure if this is a general problem, so I still left `/etc/my.cnf` as default.

In addition to that, I personally like to have all the mysql config under `/etc/mysql`. So having this configuration attribute gives us that flexibility.
