### PR TITLE
start a replication slave automatically after setup

### DIFF
--- a/templates/default/replication.sql.erb
+++ b/templates/default/replication.sql.erb
@@ -17,4 +17,6 @@ CHANGE MASTER TO
   MASTER_PORT=<%= node["percona"]["server"]["replication"]["port"] %>,
   MASTER_USER='<%= node["percona"]["server"]["replication"]["username"] %>',
   MASTER_PASSWORD='<%= @replication_password %>';
+# Start slave automatically
+START SLAVE;
 <% end -%>


### PR DESCRIPTION
As described in #25 bullet point 1: Ensure the slave is started so we don't need to do it manually.
