### PR TITLE
ensure master role is not running any slave connections

### DIFF
--- a/templates/default/replication.sql.erb
+++ b/templates/default/replication.sql.erb
@@ -8,6 +8,11 @@ GRANT REPLICATION SLAVE ON *.*
   IDENTIFIED BY '<%= @replication_password %>';
 
 FLUSH PRIVILEGES;
+i
+# Ensure this is not running as a slave, usefule for master promotion
+STOP SLAVE;
+RESET SLAVE;
+CHANGE MASTER TO MASTER_HOST='';
 <% end -%>
 
 <% if node["percona"]["server"]["role"] == "slave" %>


### PR DESCRIPTION
As described in #25 bullet point 3: When setting up a master role ensure this is not running as a slave by resetting the slave settings. This could potentially be used to promote a former slave to a master role.
