### PR TITLE
ensure replication.sql template is also run when master role is applied

### DIFF
--- a/recipes/replication.rb
+++ b/recipes/replication.rb
@@ -10,7 +10,7 @@ template "/etc/mysql/replication.sql" do
   group "root"
   mode "0600"
 
-  only_if { node["percona"]["server"]["replication"]["host"] != "" }
+  only_if { node["percona"]["server"]["replication"]["host"] != "" || node["percona"]["server"]["role"] == "master" }
 end
 
 # execute access grants


### PR DESCRIPTION
Fixed running replication template when master role is applied that has no replication host setup.
