### PR TITLE
Minor fixes to replication.sql

### DIFF
--- a/templates/default/replication.sql.erb
+++ b/templates/default/replication.sql.erb
@@ -8,11 +8,10 @@ GRANT REPLICATION SLAVE ON *.*
   IDENTIFIED BY '<%= @replication_password %>';
 
 FLUSH PRIVILEGES;
-i
+
 # Ensure this is not running as a slave, usefule for master promotion
 STOP SLAVE;
 RESET SLAVE;
-CHANGE MASTER TO MASTER_HOST='';
 <% end -%>
 
 <% if node["percona"]["server"]["role"] == "slave" %>


### PR DESCRIPTION
"CHANGE MASTER TO MASTER_HOST=''" no longer works as of Mysql 5.5. It's unnecessary (useful, but unnecessary), so just taking it out. Also removing a stray "i" that crept into the replication template.
