### PR TITLE
Fix dangerous bug in my.cnf.slave.erb

### DIFF
--- a/templates/default/my.cnf.slave.erb
+++ b/templates/default/my.cnf.slave.erb
@@ -245,9 +245,12 @@ read_only
 <% end %>
 
 log_bin          = <%= node["percona"]["server"]["datadir"] %>/mysql-bin.log
-binlog-do-db     = <%= node["percona"]["server"]["binlog_do_db"] %>
 expire_logs_days = <%= node["percona"]["server"]["expire_logs_days"] %>
 max_binlog_size  = <%= node["percona"]["server"]["max_binlog_size"] %>
+
+<% node["percona"]["server"]["binlog_do_db"].each do |db_name| %>
+binlog-do-db     = <%= db_name %>
+<% end -%>
 
 # The size of the cache to hold the SQL statements for the binary log
 # during a transaction. If you often use big, multi-statement


### PR DESCRIPTION
It's for the binlog-do-db setting; in the attributes file, we're storing it as an array of strings, and then writing each one individually into the my.cnf.master.erb (as one should do, that's how that setting works). But the my.cnf.slave.erb treats the attribute like a single string, not an array of strings. This results in a slave writing a value of (for example) "[]" for it's binlog-do-db setting. If you then promote that slave to master, it won't write ANY updates to the bin log. Replication will _appear_ to be running normally, but since the new master's not writing anything to its bin log, you're not getting any replication. Extremely dangerous, and I expect it's a real problem in any systems that have currently deployed a master-slave setup with this cookbook.
