### PR TITLE
Fix reinstall issues Centos5.

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -11,6 +11,7 @@ when "rhel"
   # Need to remove this to avoid conflicts
   package "mysql-libs" do
     action :remove
+    not_if "rpm -qa | grep Percona-Server-shared-55"
   end
 
   # we need mysqladmin


### PR DESCRIPTION
Avoid reinstall every time one Centos 5. If the proper libs installed no removal required.
