### PR TITLE
Pin the percona repo 

### DIFF
--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -16,6 +16,14 @@ when "debian"
     action :add
     notifies :run, "execute[apt-get update]", :immediately
   end
+  
+  # Pin this repo as to avoid conflicts with others
+  apt_preference "00percona" do
+    package_name "*"
+    pin " release o=Percona Development Team"
+    pin_priority "1001"
+  end
+  
 
   # install dependent package
   package "libmysqlclient-dev" do


### PR DESCRIPTION
When I tried installing on a ubuntu - precise x86_64 , it bombed with 

```
[2013-01-23T16:18:55-02:00] INFO: Processing package[libmysqlclient-dev] action install (percona::package_repo line 21)
[2013-01-23T16:20:19-02:00] INFO: Processing package[percona-server-server] action install (percona::server line 6)

================================================================================
Error executing action `install` on resource 'package[percona-server-server]'
================================================================================

Chef::Exceptions::Exec
----------------------
apt-get -q -y --force-yes install percona-server-server=5.5.28-rel29.3-388.precise returned 100, expected 0
```

Later i found the issue being libmysqlclient-dev package coming from another repo and that created a whole bunch of conflicts.

Pinning the percona repo with high priority solved it - (libmysqlclient-dev got installed from the percona repo)
