### PR TITLE
Fixes for custom datadir setting use case

### DIFF
--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -35,6 +35,20 @@ directory "/etc/mysql" do
   mode 0755
 end
 
+# setup the data directory
+directory datadir do
+  owner user
+  group user
+  recursive true
+  action :create
+end
+
+# install db to the data directory
+execute "setup mysql datadir" do
+  command "mysql_install_db --user=#{user} --datadir=#{datadir}"
+  not_if "test -f #{datadir}/mysql/user.frm"
+end
+
 # setup the main server config file
 template percona["main_config_file"] do
   source "my.cnf.#{conf ? "custom" : server["role"]}.erb"
@@ -44,24 +58,10 @@ template percona["main_config_file"] do
   notifies :restart, "service[mysql]", :immediately
 end
 
-# setup the data directory
-directory datadir do
-  owner user
-  group user
-  recursive true
-  action :create
-end
-
 # now let's set the root password only if this is the initial install
 execute "Update MySQL root password" do
   command "mysqladmin -u root password '#{passwords.root_password}'"
   not_if "test -f /etc/mysql/grants.sql"
-end
-
-# install db to the data directory
-execute "setup mysql datadir" do
-  command "mysql_install_db --user=#{user} --datadir=#{datadir}"
-  not_if "test -f #{datadir}/mysql/user.frm"
 end
 
 # setup the debian system user config


### PR DESCRIPTION
When using the following attributes I needed this patch to get a successful chef-client run.

``` ruby
set["percona"]["server"]["datadir"]          = "/data/mysql"
set["percona"]["conf"]["mysqld"]["datadir"]  = "/data/mysql"
set["percona"]["conf"]["mysqld"]["pid-file"] = "/data/mysql/mysqld.pid"
set["percona"]["conf"]["mysqld"]["socket"]   = "/data/mysql/mysqld.sock"
set["percona"]["conf"]["client"]["socket"]   = "/data/mysql/mysqld.sock"
```

I also tested without the above attributes to make sure it still worked as well.
