### PR TITLE
Fixed the incorrect root password reference

### DIFF
--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -7,7 +7,7 @@ mysqld  = (conf && conf["mysqld"]) || {}
 passwords = EncryptedPasswords.new(node, percona["encrypted_data_bag"])
 
 template "/root/.my.cnf" do
-  variables( :root_password => passwords['root'] )
+  variables( :root_password => passwords.root_password )
   owner 'root'
   group 'root'
   mode '600'


### PR DESCRIPTION
When we ran the code with encrypted data bag, we got an error:

undefined method `[]' for #Chef::EncryptedPasswords:0x0000001f8bb9f0

We found out that, passwords['root'] should be passwords.root_password

This is the pull request.
