### PR TITLE
Fixes a no method error when accessing root password

### DIFF
--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -7,7 +7,7 @@ mysqld  = (conf && conf["mysqld"]) || {}
 passwords = EncryptedPasswords.new(node, percona["encrypted_data_bag"])
 
 template "/root/.my.cnf" do
-  variables( :root_password => passwords['root'] )
+  variables( :root_password => passwords.root_password )
   owner 'root'
   group 'root'
   mode '600'


### PR DESCRIPTION
NoMethodError

---

undefined method `[]' for #Chef::EncryptedPasswords:0x0000000235fd48

Cookbook Trace:

---

  /srv/chef/file_store/cookbooks/percona/recipes/configure_server.rb:10:in `block in from_file'
  /srv/chef/file_store/cookbooks/percona/recipes/configure_server.rb:9:in`from_file'
  /srv/chef/file_store/cookbooks/percona/recipes/server.rb:25:in `from_file'

Relevant File Content:

---

/srv/chef/file_store/cookbooks/percona/recipes/configure_server.rb:

  3:  conf    = percona["conf"]
  4:  mysqld  = (conf && conf["mysqld"]) || {}
  5:  
  6:  # construct an encrypted passwords helper -- giving it the node and bag name
  7:  passwords = EncryptedPasswords.new(node, percona["encrypted_data_bag"])
  8:  
  9:  template "/root/.my.cnf" do
 10>>   variables( :root_password => passwords['root'] )
 11:    owner 'root'
 12:    group 'root'
 13:    mode '600'
