### PR TITLE
allow attribute to control server restart on config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Above shows the encrypted password in the data bag. Check out the `encrypted_dat
 ## Attributes
 
 ```ruby
+# Always restart percona on configuration changes
+default["percona"]["auto_restart"] = true
+
 case node["platform_family"]
 when "debian"
   default["percona"]["server"]["socket"]                        = "/var/run/mysqld/mysqld.sock"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,9 @@
 
 ::Chef::Node.send(:include, Opscode::OpenSSL::Password)
 
+# Always restart percona on configuration changes
+default["percona"]["auto_restart"] = true
+
 case node["platform_family"]
 when "debian"
   default["percona"]["server"]["socket"]                        = "/var/run/mysqld/mysqld.sock"

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -63,7 +63,7 @@ template percona["main_config_file"] do
   owner "root"
   group "root"
   mode 0744
-  notifies :restart, "service[mysql]", :immediately
+  notifies :restart, "service[mysql]", :immediately if node["percona"]["auto_restart"]
 end
 
 # now let's set the root password only if this is the initial install
@@ -79,7 +79,7 @@ template "/etc/mysql/debian.cnf" do
   owner "root"
   group "root"
   mode 0640
-  notifies :restart, "service[mysql]", :immediately
+  notifies :restart, "service[mysql]", :immediately if node["percona"]["auto_restart"]
 
   only_if { node["platform_family"] == "debian" }
 end


### PR DESCRIPTION
Regarding #47
- Added `auto_restart` attribute, default `true`
- Changed `configure_server` to honor attribute on notifies
- Updated README
