### PR TITLE
Do not specify the `-p` option when initially setting root password

### DIFF
--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -68,7 +68,7 @@ end
 
 # now let's set the root password only if this is the initial install
 execute "Update MySQL root password" do
-  command "mysqladmin -u root -p'' password '#{passwords.root_password}'"
+  command "mysqladmin -u root password '#{passwords.root_password}'"
   not_if "test -f /etc/mysql/grants.sql"
 end
 


### PR DESCRIPTION
I was running into an issue on first run where the `-p''` in the mysqladmin command would end up halting the run to request a password. Since no password is initially set for root, this would fail. Update here simply takes out the option for initial password set.
