### PR TITLE
Update template for .my.cnf. Add section for mysqladmin, mysqldump

### DIFF
--- a/templates/default/my.cnf.root.erb
+++ b/templates/default/my.cnf.root.erb
@@ -1,3 +1,5 @@
-[client]
+<% %w[client mysqladmin mysqldump].each do |record| -%>
+[<%= record %>]
 user=root
 password='<%= @root_password %>'
+<% end -%>


### PR DESCRIPTION
Hi,
About it [pull request #53](https://github.com/phlipper/chef-percona/pull/53). I fixed the same with mysqldump and mysqladmin for munin in past. I didn't use percona yet.
And you can find on [stackoverflow](http://stackoverflow.com/questions/9293042/mysqldump-without-the-password-prompt) questions like this.
I think more pretty will be update template.
What do you think?
