### PR TITLE
Add not_if to packages_repo.rb

### DIFF
--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -15,15 +15,16 @@ when "debian"
     key "1C4CBDCDCD2EFD2A"
     action :add
     notifies :run, "execute[apt-get update]", :immediately
+    not_if "apt-key list | grep CD2EFD2A"
   end
-  
+
   # Pin this repo as to avoid conflicts with others
   apt_preference "00percona" do
     package_name "*"
     pin " release o=Percona Development Team"
     pin_priority "1001"
   end
-  
+
 
   # install dependent package
   package "libmysqlclient-dev" do


### PR DESCRIPTION
Problem - try add apk-key on every run chef-client
And I got few errors. With timeout or network problems.
As example:
`---- Begin output of apt-key adv --keyserver keys.gnupg.net --recv 1C4CBDCDCD2EFD2A ----
STDOUT: Executing: gpg --ignore-time-conflict --no-options --no-default-keyring --secret-keyring /tmp/tmp.oiRYKunQxV --trustdb-name /etc/apt/trustdb.gpg --keyring /etc/apt/trusted.gpg --primary-keyring /etc/apt/trusted.gpg --keyserver keys.gnupg.net --recv 1C4CBDCDCD2EFD2A
gpgkeys: key 1C4CBDCDCD2EFD2A not found on keyserver
STDERR: gpg: requesting key CD2EFD2A from hkp server keys.gnupg.net
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
---- End output of apt-key adv --keyserver keys.gnupg.net --recv 1C4CBDCDCD2EFD2A ----`
