### PR TITLE
fix apt_key_id to apt_key

### DIFF
--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -20,7 +20,7 @@ when "debian"
     distribution node['lsb']['codename']
     components [ "main" ]
     keyserver node['percona']['apt_keyserver']
-    key node['percona']['apt_key_id']
+    key node['percona']['apt_key']
     action :add
   end
 


### PR DESCRIPTION
The attribute name is apt_key in attributes and apt_key_id in the recipe. This small patch fixes this.
