### PR TITLE
Fixing table_cache variable for mysql versions 5.6 and above

### DIFF
--- a/templates/default/my.cnf.master.erb
+++ b/templates/default/my.cnf.master.erb
@@ -171,7 +171,11 @@ max_connect_errors = <%= node["percona"]["server"]["max_connect_errors"] %>
 # The number of open tables for all threads.
 # make sure that the open file limit is at least twice this in the
 # mysqld_safe section
-table_cache = <%= node["percona"]["server"]["table_cache"] %>
+<%- if node['mysql']['version'].to_f >= 5.6 %>
+table_open_cache        = <%= node["percona"]["server"]["table_cache"] %>
+<%- else %>
+table_cache             = <%= node["percona"]["server"]["table_cache"] %>
+<%- end %>
 
 #thread_concurrency     = 10
 #

--- a/templates/default/my.cnf.slave.erb
+++ b/templates/default/my.cnf.slave.erb
@@ -171,7 +171,11 @@ max_connect_errors = <%= node["percona"]["server"]["max_connect_errors"] %>
 # The number of open tables for all threads.
 # make sure that the open file limit is at least twice this in the
 # mysqld_safe section
-table_cache = <%= node["percona"]["server"]["table_cache"] %>
+<%- if node['mysql']['version'].to_f >= 5.6 %>
+table_open_cache        = <%= node["percona"]["server"]["table_cache"] %>
+<%- else %>
+table_cache             = <%= node["percona"]["server"]["table_cache"] %>
+<%- end %>
 
 #thread_concurrency     = 10
 #


### PR DESCRIPTION
Not sure if it's the best way to do things (using an attribute from mysql), but I think, even if we're not specifically allowing version tuning atm, it's nice to support table_open_cache for 5.6+. I'm using chef-rewind to ensure the latest version, for instance 
