### PR TITLE
Add requirements to Berksfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,11 +2,11 @@ site :opscode
 
 metadata
 
-cookbook "yum",
+cookbook 'apt', '~> 1.9'
+cookbook 'mysql', '~> 3.0'
+cookbook 'openssl'
+cookbook 'yum',
   # Pending PR: https://github.com/opscode-cookbooks/yum/pull/49
   :git => 'https://github.com/patcon/yum',
   :ref => 'COOK-3145-better-epel-key-url'
 
-group :integration do
-  # cookbook "mysql"
-end


### PR DESCRIPTION
Right now the requirements as defined in metadata.rb are not in the Berkfile, so people who rely on berks for dependency management will get errors unless they already happen to use compatible versions of the apt, mysql and openssl cookbooks. By adding these explicitly to the Berksfile we allow berks to do proper dependency resolution to avoid these errors.
