### PR TITLE
Fix access grants on initial install

### DIFF
--- a/recipes/access_grants.rb
+++ b/recipes/access_grants.rb
@@ -20,3 +20,11 @@ execute "mysql-install-privileges" do
   action :nothing
   subscribes :run, resources("template[/etc/mysql/grants.sql]"), :immediately
 end
+
+# This rewind can come out after https://github.com/phlipper/chef-percona/issues/91
+# and/or https://github.com/phlipper/chef-percona/issues/67 is/are fixed.
+chef_gem "chef-rewind"
+require 'chef/rewind'
+rewind "execute[mysql-install-privileges]" do
+  command "mysql -p'" + passwords.root_password + "' -e '' &> /dev/null > /dev/null &> /dev/null ; if [ $? -eq 0 ] ; then /usr/bin/mysql -p'" + passwords.root_password + "' < /etc/mysql/grants.sql ; else /usr/bin/mysql < /etc/mysql/grants.sql ; fi ;"
+end


### PR DESCRIPTION
This rewind fixes #67 and #91, and is based on @adamdunkley's fix. I realize that a rewind is not ideal as a permanent solution, but given the uncertainty of the best long-term approach in the discussion of #67, I thought a short-term fix was in order so that the cookbook does not break in the interim.
