### PR TITLE
depend on any version of apt greater than 1.9

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,7 +17,7 @@ recipe "percona::configure_server", "Used internally to manage the server config
 recipe "percona::replication",   "Used internally to grant permissions for replication."
 recipe "percona::access_grants", "Used internally to grant permissions for recipes"
 
-depends "apt", "~> 1.9"
+depends "apt", "> 1.9"
 depends "yum"
 depends "openssl"
 depends "mysql", "~> 3.0"


### PR DESCRIPTION
- 1.9\* was required before
  - 1.9.2 has issues with whyrun

see https://github.com/boundary/bprobe_cookbook/issues/10 for more details
