### PR TITLE
Works with "yum" cookbook v3.0

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,8 +5,4 @@ metadata
 cookbook 'apt', '~> 1.9'
 cookbook 'mysql', '~> 3.0'
 cookbook 'openssl'
-cookbook 'yum',
-  # Pending PR: https://github.com/opscode-cookbooks/yum/pull/49
-  :git => 'https://github.com/patcon/yum',
-  :ref => 'COOK-3145-better-epel-key-url'
-
+cookbook 'yum', '~> 3.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ recipe "percona::replication",   "Used internally to grant permissions for repli
 recipe "percona::access_grants", "Used internally to grant permissions for recipes"
 
 depends "apt", "~> 1.9"
-depends "yum"
+depends "yum", "~> 3.0"
 depends "openssl"
 depends "mysql", "~> 3.0"
 

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -27,19 +27,12 @@ when "debian"
 when "rhel"
   include_recipe "yum"
 
-  yum_key "RPM-GPG-KEY-percona" do
-    url "http://www.percona.com/downloads/RPM-GPG-KEY-percona"
-    action :add
-  end
-
   arch = node['kernel']['machine'] == "x86_64" ? "x86_64" : "i386"
   pversion = node['platform_version'].to_i
-  yum_repository "percona" do
-    repo_name "Percona"
-    description "Percona Repo"
-    url "http://repo.percona.com/centos/#{pversion}/os/#{arch}/"
-    key "RPM-GPG-KEY-percona"
-    action :add
+  yum_repository 'percona' do
+    description 'Percona Packages'
+    baseurl "http://repo.percona.com/centos/#{pversion}/os/#{arch}/"
+    gpgkey 'http://www.percona.com/downloads/RPM-GPG-KEY-percona'
+    action :create
   end
-
 end


### PR DESCRIPTION
This change makes `percona` cookbook compatible with `yum` cookbook version 3.0, which:
- removed support for `yum_key`
- changed args for `yum_repository` 

`recipes/package_repo.rb`, `Berksfile` and `metadata.rb` have been updated.

I realize this will break some folks' cookbook dependencies, and it may be better to include in a major revision bump.  Are there any of those on the horizon?  

Thanks!
