### PR TITLE
make 'connect_timeout' configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ default["percona"]["server"]["language"]                        = "/usr/share/my
 default["percona"]["server"]["skip_name_resolve"]               = false
 default["percona"]["server"]["skip_external_locking"]           = true
 default["percona"]["server"]["net_read_timeout"]                = 120
+default["percona"]["server"]["connect_timeout"]                 = 10
 default["percona"]["server"]["old_passwords"]                   = 0
 default["percona"]["server"]["bind_address"]                    = "127.0.0.1"
 %w[debian_password root_password].each do |attribute|

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,6 +66,7 @@ default["percona"]["server"]["collation"]                       = "utf8_unicode_
 default["percona"]["server"]["skip_name_resolve"]               = false
 default["percona"]["server"]["skip_external_locking"]           = true
 default["percona"]["server"]["net_read_timeout"]                = 120
+default["percona"]["server"]["connect_timeout"]                 = 10
 default["percona"]["server"]["old_passwords"]                   = 0
 default["percona"]["server"]["bind_address"]                    = "127.0.0.1"
 %w[debian_password root_password].each do |attribute|

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -55,6 +55,7 @@ skip-external-locking
 <% end %>
 
 net_read_timeout = <%= node["percona"]["server"]["net_read_timeout"] %>
+connect_timeout  = <%= node["percona"]["server"]["connect_timeout"] %>
 
 #
 # * Cluster Settings

--- a/templates/default/my.cnf.master.erb
+++ b/templates/default/my.cnf.master.erb
@@ -63,6 +63,7 @@ skip-external-locking
 <% end %>
 
 net_read_timeout = <%= node["percona"]["server"]["net_read_timeout"] %>
+connect_timeout  = <%= node["percona"]["server"]["connect_timeout"] %>
 
 #
 # For compatibility to other Debian packages that still use

--- a/templates/default/my.cnf.slave.erb
+++ b/templates/default/my.cnf.slave.erb
@@ -63,6 +63,7 @@ skip-external-locking
 <% end %>
 
 net_read_timeout = <%= node["percona"]["server"]["net_read_timeout"] %>
+connect_timeout  = <%= node["percona"]["server"]["connect_timeout"] %>
 
 #
 # For compatibility to other Debian packages that still use

--- a/templates/default/my.cnf.standalone.erb
+++ b/templates/default/my.cnf.standalone.erb
@@ -55,6 +55,7 @@ skip-external-locking
 <% end %>
 
 net_read_timeout = <%= node["percona"]["server"]["net_read_timeout"] %>
+connect_timeout  = <%= node["percona"]["server"]["connect_timeout"] %>
 
 #
 # For compatibility to other Debian packages that still use


### PR DESCRIPTION
I make use of the [connect_timeout](https://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html#sysvar_connect_timeout) system variable in many environments, usually to deal with what I call 'optimistic networking' code.. where a developer assumes the socket isn't going away from the front side of a load balancer.  I've set the default value (10) to match the default provided by MySQL so it shouldn't affect behaviour in anyone's environment unless they'd with it to.

I believe this system variable has been in MySQL for a long time, so I don't think there's any harm in assuming we can set it.
