### PR TITLE
  Set passwords if not defined attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -148,7 +148,7 @@ default["percona"]["server"]["replication"]["ignore_db"]        = ""
 # XtraBackup Settings
 default["percona"]["backup"]["configure"]                       = false
 default["percona"]["backup"]["username"]                        = "backup"
-unless defined?(node["percona"]["backup"]["password"])
+unless attribute?(node["percona"]["backup"]["password"])
   default["percona"]["backup"]["password"]                      = secure_password
 end
 


### PR DESCRIPTION
defined?( ) method over an absent key in a hash, results "method". In conditional statement evaluates to true. Use attribute?( ) instead.
