### PR TITLE
Force client to be 5.5

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -1,6 +1,6 @@
 case node["platform_family"]
 when "debian"
-  normal['mysql']['client']['packages'] = %w{libmysqlclient-dev percona-server-client}
+  normal['mysql']['client']['packages'] = %w{libmysqlclient-dev percona-server-client-5.5}
 when "rhel"
   normal['mysql']['client']['packages'] = %w{Percona-Server-client-55}
 end


### PR DESCRIPTION
It seems that now percona installs client version 5.6 and that breaks the installation of the server.  It would be best if we specify client version 5.5 to be installed.
