### PR TITLE
Fix debian-sys-maint grant for installs with moved datadir

### DIFF
--- a/templates/default/grants.sql.erb
+++ b/templates/default/grants.sql.erb
@@ -3,10 +3,10 @@
 
 <% if node["platform_family"] == "debian" -%>
 # debian-sys-maint user for administration
-SET PASSWORD FOR '<%= @debian_user %>'@'localhost' = PASSWORD('<%= @debian_password %>');
   <% [['SELECT', 'mysql.user'], ['SHUTDOWN', '*.*']].each do |priv, loc| %>
 <%= "GRANT #{priv} ON #{loc} TO '#{@debian_user}'@'localhost';" %>
   <% end -%>
+  SET PASSWORD FOR '<%= @debian_user %>'@'localhost' = PASSWORD('<%= @debian_password %>');
 <% end -%>
 
 


### PR DESCRIPTION
I actually introduced this issue, but I was previously moving the data to its new location rather than using the built-in approach to create new data, so I hadn't run into it.

If we have set a `server.datadir` other than `/var/lib/mysql`, the `debian-sys-maint` user won't already exist in the newly-created database. That means that the password set will fail.  Moving the password after the grants fixes that.
