### PR TITLE
Fixed missing MySQL log directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ default["percona"]["server"]["enable"]                          = true
 default["percona"]["server"]["role"]                            = "standalone"
 default["percona"]["server"]["username"]                        = "mysql"
 default["percona"]["server"]["datadir"]                         = "/var/lib/mysql"
+default["percona"]["server"]["logdir"]                         = "/var/log/mysql"
 default["percona"]["server"]["tmpdir"]                          = "/tmp"
 default["percona"]["server"]["debian_username"]                 = "debian-sys-maint"
 default["percona"]["server"]["nice"]                            = 0

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,6 +40,7 @@ default["percona"]["server"]["enable"]                          = true
 default["percona"]["server"]["role"]                            = "standalone"
 default["percona"]["server"]["username"]                        = "mysql"
 default["percona"]["server"]["datadir"]                         = "/var/lib/mysql"
+default["percona"]["server"]["logdir"]                          = "/var/log/mysql"
 default["percona"]["server"]["tmpdir"]                          = "/tmp"
 default["percona"]["server"]["debian_username"]                 = "debian-sys-maint"
 default["percona"]["server"]["nice"]                            = 0

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -33,6 +33,7 @@ if server["bind_to"]
 end
 
 datadir = mysqld["datadir"] || server["datadir"]
+logdir  = mysqld["logdir"] || server["logdir"]
 tmpdir  = mysqld["tmpdir"] || server["tmpdir"]
 user    = mysqld["username"] || server["username"]
 
@@ -45,6 +46,13 @@ end
 
 # setup the data directory
 directory datadir do
+  owner user
+  group user
+  recursive true
+end
+
+# setup the log directory
+directory logdir do
   owner user
   group user
   recursive true


### PR DESCRIPTION
Fix to create /var/log/mysql directory which is expected by:

default["percona"]["server"]["slow_query_log_file"] = "/var/log/mysql/mysql-slow.log"

Without this MySQL server returns the following error:

140522 17:19:24 [ERROR] Could not use /var/log/mysql/mysql-slow.log for logging (error 2). Turning logging off for the whole duration of the MySQL server process. To turn it on again: fix the cause, shutdown the MySQL server and restart it.
