### PR TITLE
Data-driven Percona YUM repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ default["percona"]["plugins_version"] = "1.1.3"
 default["percona"]["plugins_packages"] = %w[percona-nagios-plugins percona-zabbix-templates percona-cacti-templates]
 ```
 
+### Package_repo.rb
+
+```ruby
+default["percona"]["yum"]["description"] = "Percona Packages"
+default["percona"]["yum"]["baseurl"]     = "http://repo.percona.com/centos/#{pversion}/os/#{arch}/"
+default["percona"]["yum"]["gpgkey"]      = "http://www.percona.com/downloads/RPM-GPG-KEY-percona"
+default["percona"]["yum"]["gpgcheck"]    = true
+default["percona"]["yum"]["sslverify"]   = true
+```
+
 ## Explicit my.cnf templating
 
 In some situation it is preferable to explicitly define the attributes needed in a `my.cnf` file. This is enabled by adding categories to the `node[:percona][:conf]` attributes. All keys found in the `node[:percona][:conf]` map will represent categories in the `my.cnf` file. Each category contains a map of attributes that will be written to the `my.cnf` file for that category. See the example for more details.

--- a/attributes/package_repo.rb
+++ b/attributes/package_repo.rb
@@ -7,3 +7,13 @@ default["percona"]["use_percona_repos"] = true
 default["percona"]["apt_uri"] = "http://repo.percona.com/apt"
 default["percona"]["apt_keyserver"] = "keys.gnupg.net"
 default["percona"]["apt_key"] = "CD2EFD2A"
+
+arch = node["kernel"]["machine"] == "x86_64" ? "x86_64" : "i386"
+pversion = node["platform_version"].to_i
+
+default["percona"]["yum"]["description"] = "Percona Packages"
+default["percona"]["yum"]["baseurl"] = "http://repo.percona.com/centos/#{pversion}/os/#{arch}/"
+default["percona"]["yum"]["gpgkey"] = "http://www.percona.com/downloads/RPM-GPG-KEY-percona"
+default["percona"]["yum"]["gpgcheck"] = true
+default["percona"]["yum"]["sslverify"] = true
+

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -28,13 +28,12 @@ when "debian"
 when "rhel"
   include_recipe "yum"
 
-  arch = node["kernel"]["machine"] == "x86_64" ? "x86_64" : "i386"
-  pversion = node["platform_version"].to_i
-
   yum_repository "percona" do
-    description "Percona Packages"
-    baseurl "http://repo.percona.com/centos/#{pversion}/os/#{arch}/"
-    gpgkey "http://www.percona.com/downloads/RPM-GPG-KEY-percona"
+    description node["percona"]["yum"]["description"]
+    baseurl node["percona"]["yum"]["baseurl"]
+    gpgkey node["percona"]["yum"]["gpgkey"]
+    gpgcheck node["percona"]["yum"]["gpgcheck"]
+    sslverify node["percona"]["yum"]["sslverify"]
     action :create
   end
 end


### PR DESCRIPTION
Adds the ability to use private internal YUM repositories for sourcing packages.

Relates to issue #126.
