### PR TITLE
Added support for jemalloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ default["percona"]["server"]["username"]                        = "mysql"
 default["percona"]["server"]["datadir"]                         = "/var/lib/mysql"
 default["percona"]["server"]["tmpdir"]                          = "/tmp"
 default["percona"]["server"]["debian_username"]                 = "debian-sys-maint"
+default["percona"]["server"]["jemalloc"]                        = false
 default["percona"]["server"]["nice"]                            = 0
 default["percona"]["server"]["open_files_limit"]                = 16384
 default["percona"]["server"]["hostname"]                        = "localhost"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,6 +42,7 @@ default["percona"]["server"]["username"]                        = "mysql"
 default["percona"]["server"]["datadir"]                         = "/var/lib/mysql"
 default["percona"]["server"]["tmpdir"]                          = "/tmp"
 default["percona"]["server"]["debian_username"]                 = "debian-sys-maint"
+default["percona"]["server"]["jemalloc"]              		= false
 default["percona"]["server"]["nice"]                            = 0
 default["percona"]["server"]["open_files_limit"]                = 16_384
 default["percona"]["server"]["hostname"]                        = "localhost"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -25,6 +25,11 @@ when "rhel"
   package node["percona"]["server"]["package"] do
     action :install
   end
+
+  if node["percona"]["server"]["jemalloc"]
+    package "jemalloc"
+  end
+
 end
 
 unless node["percona"]["skip_configure"]

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -29,6 +29,9 @@ socket = <%= node["percona"]["server"]["socket"] %>
 socket           = <%= node["percona"]["server"]["socket"] %>
 nice             = <%= node["percona"]["server"]["nice"] %>
 open-files-limit = <%= node["percona"]["server"]["open_files_limit"] %>
+<% if node["percona"]["server"]["jemalloc"] %>
+malloc-lib       = /usr/lib64/libjemalloc.so.1
+<% end %>
 
 [mysqld]
 #

--- a/templates/default/my.cnf.master.erb
+++ b/templates/default/my.cnf.master.erb
@@ -31,6 +31,9 @@ interactive-timeout
 socket           = <%= node["percona"]["server"]["socket"] %>
 nice             = <%= node["percona"]["server"]["nice"] %>
 open-files-limit = <%= node["percona"]["server"]["open_files_limit"] %>
+<% if node["percona"]["server"]["jemalloc"] %>
+malloc-lib       = /usr/lib64/libjemalloc.so.1
+<% end %>
 
 # *** Application-specific options follow here ***
 

--- a/templates/default/my.cnf.slave.erb
+++ b/templates/default/my.cnf.slave.erb
@@ -31,6 +31,9 @@ interactive-timeout
 socket           = <%= node["percona"]["server"]["socket"] %>
 nice             = <%= node["percona"]["server"]["nice"] %>
 open-files-limit = <%= node["percona"]["server"]["open_files_limit"] %>
+<% if node["percona"]["server"]["jemalloc"] %>
+malloc-lib       = /usr/lib64/libjemalloc.so.1
+<% end %>
 
 # *** Application-specific options follow here ***
 

--- a/templates/default/my.cnf.standalone.erb
+++ b/templates/default/my.cnf.standalone.erb
@@ -29,6 +29,9 @@ socket = <%= node["percona"]["server"]["socket"] %>
 socket           = <%= node["percona"]["server"]["socket"] %>
 nice             = <%= node["percona"]["server"]["nice"] %>
 open-files-limit = <%= node["percona"]["server"]["open_files_limit"] %>
+<% if node["percona"]["server"]["jemalloc"] %>
+malloc-lib       = /usr/lib64/libjemalloc.so.1
+<% end %>
 
 [mysqld]
 #


### PR DESCRIPTION
This provides the ability to use the jemalloc memory allocation library for increased performance in high concurrency environments.

http://www.mysqlperformanceblog.com/2012/07/05/impact-of-memory-allocators-on-mysql-performance/

Note: The jemalloc package is provided by Percona in their YUM repository.
