### PR TITLE
Update default for wsrep_provider on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,10 @@ end
 # XtraDB Cluster Settings
 default["percona"]["cluster"]["package"]                        = "percona-xtradb-cluster-55"
 default["percona"]["cluster"]["binlog_format"]                  = "ROW"
-default["percona"]["cluster"]["wsrep_provider"]                 = "/usr/lib64/libgalera_smm.so"
+default["percona"]["cluster"]["wsrep_provider"]                 = value_for_platform_family(
+                                                                    "debian" => "/usr/lib/libgalera_smm.so",
+                                                                    "rhel" => "/usr/lib64/libgalera_smm.so"
+                                                                  )
 default["percona"]["cluster"]["wsrep_cluster_address"]          = ""
 default["percona"]["cluster"]["wsrep_slave_threads"]            = 2
 default["percona"]["cluster"]["wsrep_cluster_name"]             = ""

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -155,7 +155,10 @@ end
 # XtraDB Cluster Settings
 default["percona"]["cluster"]["package"]                        = "percona-xtradb-cluster-55"
 default["percona"]["cluster"]["binlog_format"]                  = "ROW"
-default["percona"]["cluster"]["wsrep_provider"]                 = "/usr/lib64/libgalera_smm.so"
+default["percona"]["cluster"]["wsrep_provider"]                 = value_for_platform_family(
+                                                                    "debian" => "/usr/lib/libgalera_smm.so",
+                                                                    "rhel" => "/usr/lib64/libgalera_smm.so"
+                                                                  )
 default["percona"]["cluster"]["wsrep_cluster_address"]          = ""
 default["percona"]["cluster"]["wsrep_slave_threads"]            = 2
 default["percona"]["cluster"]["wsrep_cluster_name"]             = ""


### PR DESCRIPTION
'libgalera_smm.so' is in a different location in the Debian packages from Percona.  This quick fix sets a platform specific default.
