### PR TITLE
Enable InnoDB tuning for standalone and cluster

### DIFF
--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -153,6 +153,141 @@ max_binlog_size  = <%= node["percona"]["server"]["max_binlog_size"] %>
 #
 # InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
 # Read the manual for more InnoDB related options. There are many!
+
+# Use this option if you have a MySQL server with InnoDB support enabled
+# but you do not plan to use it. This will save memory and disk space
+# and speed up some things.
+<% if node["percona"]["server"]["skip_innodb"] %>
+skip-innodb
+<% end %>
+
+# Additional memory pool that is used by InnoDB to store metadata
+# information.  If InnoDB requires more memory for this purpose it will
+# start to allocate it from the OS.  As this is fast enough on most
+# recent operating systems, you normally do not need to change this
+# value. SHOW INNODB STATUS will display the current amount used.
+innodb_additional_mem_pool_size = <%= node["percona"]["server"]["innodb_additional_mem_pool_size"] %>
+
+# This config file assumes a main memory of at least 8G
+innodb_buffer_pool_size = <%= node["percona"]["server"]["innodb_buffer_pool_size"] %>
+
+# InnoDB stores data in one or more data files forming the tablespace.
+# If you have a single logical drive for your data, a single
+# autoextending file would be good enough. In other cases, a single file
+# per device is often a good choice. You can configure InnoDB to use raw
+# disk partitions as well - please refer to the manual for more info
+# about this.
+
+# to prevent fragmentation of the InnoDB tablespace, either create a
+# very big initial datafile, or set the autoextend amount to a large
+# value.  The disadvantage of using a large autoextend size is that the
+# server may take some time to extend the file when needed
+
+# can't specify tablespace sizes for innodb-file-per-table tablespaces
+# so using a big autoextend is preferable in those cases.
+innodb_data_file_path = <%= node["percona"]["server"]["innodb_data_file_path"] %>
+# innodb_autoextend_increment = 128M
+<% if node["percona"]["server"]["innodb_file_per_table"] %>
+innodb_file_per_table
+<% end %>
+
+# The file format to use for new InnoDB tables.
+# Currently Antelope and Barracuda are supported.
+# This applies only for tables that have their own tablespace,
+# so for it to have an effect innodb_file_per_table must be enabled.
+innodb_file_format = <%= node["percona"]["server"]["innodb_file_format"] %>
+
+# Set this option if you would like the InnoDB tablespace files to be
+# stored in another location. By default this is the MySQL datadir.
+<% if !node["percona"]["server"]["innodb_data_home_dir"].empty? %>
+innodb_data_home_dir = <%= node["percona"]["server"]["innodb_data_home_dir"] %>
+<% end %>
+
+# Number of threads allowed inside the InnoDB kernel. The optimal value
+# depends highly on the application, hardware as well as the OS
+# scheduler properties. A too high value may lead to thread thrashing.
+innodb_thread_concurrency = <%= node["percona"]["server"]["innodb_thread_concurrency"] %>
+
+# If set to 1, InnoDB will flush (fsync) the transaction logs to the
+# disk at each commit, which offers full ACID behavior. If you are
+# willing to compromise this safety, and you are running small
+# transactions, you may set this to 0 or 2 to reduce disk I/O to the
+# logs. Value 0 means that the log is only written to the log file and
+# the log file flushed to disk approximately once per second. Value 2
+# means the log is written to the log file at each commit, but the log
+# file is only flushed to disk approximately once per second.
+innodb_flush_log_at_trx_commit = <%= node["percona"]["server"]["innodb_flush_log_at_trx_commit"] %>
+
+# Speed up InnoDB shutdown. This will disable InnoDB to do a full purge
+# and insert buffer merge on shutdown. It may increase shutdown time a
+# lot, but InnoDB will have to do it on the next startup instead.
+<% if node["percona"]["server"]["innodb_fast_shutdown"] %>
+innodb_fast_shutdown
+<% end %>
+
+# The size of the buffer InnoDB uses for buffering log data. As soon as
+# it is full, InnoDB will have to flush it to disk. As it is flushed
+# once per second anyway, it does not make sense to have it very large
+# (even with long transactions).
+innodb_log_buffer_size = <%= node["percona"]["server"]["innodb_log_buffer_size"] %>
+
+# Size of each log file in a log group. You should set the combined size
+# of log files to about 25%-100% of your buffer pool size to avoid
+# unneeded buffer pool flush activity on log file overwrite. However,
+# note that a larger logfile size will increase the time needed for the
+# recovery process.
+
+# make sure the log files are large enough that you don't hold up
+# checkpoints when the logs rotate!
+innodb_log_file_size = <%= node["percona"]["server"]["innodb_log_file_size"] %>
+
+# Total number of files in the log group. A value of 2-3 is usually good
+# enough.
+innodb_log_files_in_group = <%= node["percona"]["server"]["innodb_log_files_in_group"] %>
+
+# Location of the InnoDB log files. Default is the MySQL datadir. You
+# may wish to point it to a dedicated hard drive or a RAID1 volume for
+# improved performance
+
+# be careful if you use LVM and plan to snapshot your filesystem for hot
+# backup.  your log files must be on the same logical volume as your data
+# files in order for this to work.
+
+#innodb_log_group_home_dir
+
+# Maximum allowed percentage of dirty pages in the InnoDB buffer pool.
+# If it is reached, InnoDB will start flushing them out agressively to
+# not run out of clean pages at all. This is a soft limit, not
+# guaranteed to be held.
+innodb_max_dirty_pages_pct = <%= node["percona"]["server"]["innodb_max_dirty_pages_pct"] %>
+
+# The flush method InnoDB will use for Log. The tablespace always uses
+# doublewrite flush logic. The default value is "fdatasync", another
+# option is "O_DSYNC".
+
+# use directIO to bypass filesystem cache where possible
+innodb_flush_method = <%= node["percona"]["server"]["innodb_flush_method"] %>
+
+# How long an InnoDB transaction should wait for a lock to be granted
+# before being rolled back. InnoDB automatically detects transaction
+# deadlocks in its own lock table and rolls back the transaction. If you
+# use the LOCK TABLES command, or other transaction-safe storage engines
+# than InnoDB in the same transaction, then a deadlock may arise which
+# InnoDB cannot notice. In cases like this the timeout is useful to
+# resolve the situation.
+innodb_lock_wait_timeout = <%= node["percona"]["server"]["innodb_lock_wait_timeout"] %>
+
+# Let as many clients commit at once as necessary
+# If you have a very intensive write application or if you have
+# innodb_flush_logs_at_trx <> 1 it may make sense to play with this.
+
+# with this configuration it probably won't matter anyway, because binary
+# logging is enabled, which enforces serialized commits, even when the
+# isolation level isn't serializable.
+innodb_commit_concurrency=0
+
+innodb_open_files=2000
+
 #
 # * Security Features
 #

--- a/templates/default/my.cnf.standalone.erb
+++ b/templates/default/my.cnf.standalone.erb
@@ -137,6 +137,141 @@ max_binlog_size  = <%= node["percona"]["server"]["max_binlog_size"] %>
 #
 # InnoDB is enabled by default with a 10MB datafile in /var/lib/mysql/.
 # Read the manual for more InnoDB related options. There are many!
+
+# Use this option if you have a MySQL server with InnoDB support enabled
+# but you do not plan to use it. This will save memory and disk space
+# and speed up some things.
+<% if node["percona"]["server"]["skip_innodb"] %>
+skip-innodb
+<% end %>
+
+# Additional memory pool that is used by InnoDB to store metadata
+# information.  If InnoDB requires more memory for this purpose it will
+# start to allocate it from the OS.  As this is fast enough on most
+# recent operating systems, you normally do not need to change this
+# value. SHOW INNODB STATUS will display the current amount used.
+innodb_additional_mem_pool_size = <%= node["percona"]["server"]["innodb_additional_mem_pool_size"] %>
+
+# This config file assumes a main memory of at least 8G
+innodb_buffer_pool_size = <%= node["percona"]["server"]["innodb_buffer_pool_size"] %>
+
+# InnoDB stores data in one or more data files forming the tablespace.
+# If you have a single logical drive for your data, a single
+# autoextending file would be good enough. In other cases, a single file
+# per device is often a good choice. You can configure InnoDB to use raw
+# disk partitions as well - please refer to the manual for more info
+# about this.
+
+# to prevent fragmentation of the InnoDB tablespace, either create a
+# very big initial datafile, or set the autoextend amount to a large
+# value.  The disadvantage of using a large autoextend size is that the
+# server may take some time to extend the file when needed
+
+# can't specify tablespace sizes for innodb-file-per-table tablespaces
+# so using a big autoextend is preferable in those cases.
+innodb_data_file_path = <%= node["percona"]["server"]["innodb_data_file_path"] %>
+# innodb_autoextend_increment = 128M
+<% if node["percona"]["server"]["innodb_file_per_table"] %>
+innodb_file_per_table
+<% end %>
+
+# The file format to use for new InnoDB tables.
+# Currently Antelope and Barracuda are supported.
+# This applies only for tables that have their own tablespace,
+# so for it to have an effect innodb_file_per_table must be enabled.
+innodb_file_format = <%= node["percona"]["server"]["innodb_file_format"] %>
+
+# Set this option if you would like the InnoDB tablespace files to be
+# stored in another location. By default this is the MySQL datadir.
+<% if !node["percona"]["server"]["innodb_data_home_dir"].empty? %>
+innodb_data_home_dir = <%= node["percona"]["server"]["innodb_data_home_dir"] %>
+<% end %>
+
+# Number of threads allowed inside the InnoDB kernel. The optimal value
+# depends highly on the application, hardware as well as the OS
+# scheduler properties. A too high value may lead to thread thrashing.
+innodb_thread_concurrency = <%= node["percona"]["server"]["innodb_thread_concurrency"] %>
+
+# If set to 1, InnoDB will flush (fsync) the transaction logs to the
+# disk at each commit, which offers full ACID behavior. If you are
+# willing to compromise this safety, and you are running small
+# transactions, you may set this to 0 or 2 to reduce disk I/O to the
+# logs. Value 0 means that the log is only written to the log file and
+# the log file flushed to disk approximately once per second. Value 2
+# means the log is written to the log file at each commit, but the log
+# file is only flushed to disk approximately once per second.
+innodb_flush_log_at_trx_commit = <%= node["percona"]["server"]["innodb_flush_log_at_trx_commit"] %>
+
+# Speed up InnoDB shutdown. This will disable InnoDB to do a full purge
+# and insert buffer merge on shutdown. It may increase shutdown time a
+# lot, but InnoDB will have to do it on the next startup instead.
+<% if node["percona"]["server"]["innodb_fast_shutdown"] %>
+innodb_fast_shutdown
+<% end %>
+
+# The size of the buffer InnoDB uses for buffering log data. As soon as
+# it is full, InnoDB will have to flush it to disk. As it is flushed
+# once per second anyway, it does not make sense to have it very large
+# (even with long transactions).
+innodb_log_buffer_size = <%= node["percona"]["server"]["innodb_log_buffer_size"] %>
+
+# Size of each log file in a log group. You should set the combined size
+# of log files to about 25%-100% of your buffer pool size to avoid
+# unneeded buffer pool flush activity on log file overwrite. However,
+# note that a larger logfile size will increase the time needed for the
+# recovery process.
+
+# make sure the log files are large enough that you don't hold up
+# checkpoints when the logs rotate!
+innodb_log_file_size = <%= node["percona"]["server"]["innodb_log_file_size"] %>
+
+# Total number of files in the log group. A value of 2-3 is usually good
+# enough.
+innodb_log_files_in_group = <%= node["percona"]["server"]["innodb_log_files_in_group"] %>
+
+# Location of the InnoDB log files. Default is the MySQL datadir. You
+# may wish to point it to a dedicated hard drive or a RAID1 volume for
+# improved performance
+
+# be careful if you use LVM and plan to snapshot your filesystem for hot
+# backup.  your log files must be on the same logical volume as your data
+# files in order for this to work.
+
+#innodb_log_group_home_dir
+
+# Maximum allowed percentage of dirty pages in the InnoDB buffer pool.
+# If it is reached, InnoDB will start flushing them out agressively to
+# not run out of clean pages at all. This is a soft limit, not
+# guaranteed to be held.
+innodb_max_dirty_pages_pct = <%= node["percona"]["server"]["innodb_max_dirty_pages_pct"] %>
+
+# The flush method InnoDB will use for Log. The tablespace always uses
+# doublewrite flush logic. The default value is "fdatasync", another
+# option is "O_DSYNC".
+
+# use directIO to bypass filesystem cache where possible
+innodb_flush_method = <%= node["percona"]["server"]["innodb_flush_method"] %>
+
+# How long an InnoDB transaction should wait for a lock to be granted
+# before being rolled back. InnoDB automatically detects transaction
+# deadlocks in its own lock table and rolls back the transaction. If you
+# use the LOCK TABLES command, or other transaction-safe storage engines
+# than InnoDB in the same transaction, then a deadlock may arise which
+# InnoDB cannot notice. In cases like this the timeout is useful to
+# resolve the situation.
+innodb_lock_wait_timeout = <%= node["percona"]["server"]["innodb_lock_wait_timeout"] %>
+
+# Let as many clients commit at once as necessary
+# If you have a very intensive write application or if you have
+# innodb_flush_logs_at_trx <> 1 it may make sense to play with this.
+
+# with this configuration it probably won't matter anyway, because binary
+# logging is enabled, which enforces serialized commits, even when the
+# isolation level isn't serializable.
+innodb_commit_concurrency=0
+
+innodb_open_files=2000
+
 #
 # * Security Features
 #


### PR DESCRIPTION
This makes the support for all the InnoDB tuning options found in the 'master' and 'slave' templates available in the 'standalone' and 'cluster' templates.
