### PR TITLE
Added support for expand_fast_index_creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ default["percona"]["server"]["max_connections"]                 = 30
 default["percona"]["server"]["max_connect_errors"]              = 9999999
 default["percona"]["server"]["table_cache"]                     = 8192
 default["percona"]["server"]["group_concat_max_len"]            = 4096
+default["percona"]["server"]["expand_fast_index_creation"]      = false
 
 # Query Cache Configuration
 default["percona"]["server"]["query_cache_size"]                = "64M"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -78,6 +78,7 @@ default["percona"]["server"]["max_connections"]                 = 30
 default["percona"]["server"]["max_connect_errors"]              = 9_999_999
 default["percona"]["server"]["table_cache"]                     = 8192
 default["percona"]["server"]["group_concat_max_len"]            = 4096
+default["percona"]["server"]["expand_fast_index_creation"]      = false
 
 # Query Cache Configuration
 default["percona"]["server"]["query_cache_size"]                = "64M"

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -96,6 +96,10 @@ max_allowed_packet  = <%= node["percona"]["server"]["max_allowed_packet"] %>
 # Maximum String length size of a group concat result
 group_concat_max_len = <%= node["percona"]["server"]["group_concat_max_len"] %>
 
+<% if node["percona"]["server"]["expand_fast_index_creation"] %>
+expand_fast_index_creation
+
+<% end %>
 # Thread stack size to use. This amount of memory is always reserved at
 # connection time. MySQL itself usually needs no more than 64K of
 # memory, while if you use your own stack hungry UDF functions or your

--- a/templates/default/my.cnf.master.erb
+++ b/templates/default/my.cnf.master.erb
@@ -90,6 +90,10 @@ max_allowed_packet  = <%= node["percona"]["server"]["max_allowed_packet"] %>
 # Maximum String length size of a group concat result
 group_concat_max_len = <%= node["percona"]["server"]["group_concat_max_len"] %>
 
+<% if node["percona"]["server"]["expand_fast_index_creation"] %>
+expand_fast_index_creation
+
+<% end %>
 # Thread stack size to use. This amount of memory is always reserved at
 # connection time. MySQL itself usually needs no more than 64K of
 # memory, while if you use your own stack hungry UDF functions or your

--- a/templates/default/my.cnf.slave.erb
+++ b/templates/default/my.cnf.slave.erb
@@ -90,6 +90,10 @@ max_allowed_packet  = <%= node["percona"]["server"]["max_allowed_packet"] %>
 # Maximum String length size of a group concat result
 group_concat_max_len = <%= node["percona"]["server"]["group_concat_max_len"] %>
 
+<% if node["percona"]["server"]["expand_fast_index_creation"] %>
+expand_fast_index_creation
+
+<% end %>
 # Thread stack size to use. This amount of memory is always reserved at
 # connection time. MySQL itself usually needs no more than 64K of
 # memory, while if you use your own stack hungry UDF functions or your

--- a/templates/default/my.cnf.standalone.erb
+++ b/templates/default/my.cnf.standalone.erb
@@ -82,6 +82,10 @@ max_allowed_packet  = <%= node["percona"]["server"]["max_allowed_packet"] %>
 # Maximum String length size of a group concat result
 group_concat_max_len = <%= node["percona"]["server"]["group_concat_max_len"] %>
 
+<% if node["percona"]["server"]["expand_fast_index_creation"] %>
+expand_fast_index_creation
+
+<% end %>
 # Thread stack size to use. This amount of memory is always reserved at
 # connection time. MySQL itself usually needs no more than 64K of
 # memory, while if you use your own stack hungry UDF functions or your


### PR DESCRIPTION
Enables support for Percona fast index creation.

http://www.mysqlperformanceblog.com/2011/11/06/improved-innodb-fast-index-creation/
