### PR TITLE
Honor skip_configure attribute in cluster recipe

### DIFF
--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -31,7 +31,7 @@ when "rhel"
   package node["percona"]["cluster"]["package"]
 end
 
-include_recipe "percona::configure_server"
+include_recipe "percona::configure_server" unless node["percona"]["skip_configure"]
 
 # access grants
 include_recipe "percona::access_grants" unless node["percona"]["skip_passwords"]


### PR DESCRIPTION
This makes the cluster recipe behave in the same way as the server
recipe by not including configure_server if skip_configure is
true.
