### PR TITLE
XtraDB Cluster support for replication over SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ end
 default["percona"]["cluster"]["package"]                        = "percona-xtradb-cluster-55"
 default["percona"]["cluster"]["binlog_format"]                  = "ROW"
 default["percona"]["cluster"]["wsrep_provider"]                 = "/usr/lib64/libgalera_smm.so"
+default["percona"]["cluster"]["wsrep_provider_options"]         = ""
 default["percona"]["cluster"]["wsrep_cluster_address"]          = ""
 default["percona"]["cluster"]["wsrep_slave_threads"]            = 2
 default["percona"]["cluster"]["wsrep_cluster_name"]             = ""

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -156,6 +156,7 @@ end
 default["percona"]["cluster"]["package"]                        = "percona-xtradb-cluster-55"
 default["percona"]["cluster"]["binlog_format"]                  = "ROW"
 default["percona"]["cluster"]["wsrep_provider"]                 = "/usr/lib64/libgalera_smm.so"
+default["percona"]["cluster"]["wsrep_provider_options"]         = ""
 default["percona"]["cluster"]["wsrep_cluster_address"]          = ""
 default["percona"]["cluster"]["wsrep_slave_threads"]            = 2
 default["percona"]["cluster"]["wsrep_cluster_name"]             = ""

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -66,6 +66,7 @@ wait_timeout     = <%= node["percona"]["server"]["wait_timeout"] %>
 #
 binlog_format                  = <%= node["percona"]["cluster"]["binlog_format"] %>
 wsrep_provider                 = <%= node["percona"]["cluster"]["wsrep_provider"] %>
+wsrep_provider_options         = <%= node["percona"]["cluster"]["wsrep_provider_options"] %>
 wsrep_cluster_address          = <%= node["percona"]["cluster"]["wsrep_cluster_address"] %>
 wsrep_slave_threads            = <%= node["percona"]["cluster"]["wsrep_slave_threads"] %>
 wsrep_cluster_name             = <%= node["percona"]["cluster"]["wsrep_cluster_name"] %>


### PR DESCRIPTION
Allows you to adjust `wsrep_provider_options` for encrypted Galera replication. 

Example:

``` ruby
default_attributes(
  "percona" => {
    "server" => {
      "role" => "cluster",
    },

    "cluster" => {
      "package"                => "percona-xtradb-cluster-55",
      "wsrep_provider"         => "/usr/lib/libgalera_smm.so",
      "wsrep_provider_options" => '"socket.ssl_cert=/etc/mysql/galera-cert.pem;socket.ssl_key=/etc/mysql/galera-key.pem"',
      "wsrep_cluster_name"     => "foo",
    }
  }
)
```

See http://www.mysqlperformanceblog.com/2013/05/03/percona-xtradb-cluster-for-mysql-and-encrypted-galera-replication/ for more info.
