### PR TITLE
Attributes fix for percona-xtradb-cluster on RHEL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -159,7 +159,10 @@ unless attribute?(node["percona"]["backup"]["password"])
 end
 
 # XtraDB Cluster Settings
-default["percona"]["cluster"]["package"]                        = "percona-xtradb-cluster-55"
+default["percona"]["cluster"]["package"]                        = value_for_platform_family(
+                                                                    "debian" => "percona-xtradb-cluster-55",
+                                                                    "rhel" => "Percona-XtraDB-Cluster-55"
+                                                                  )
 default["percona"]["cluster"]["binlog_format"]                  = "ROW"
 default["percona"]["cluster"]["wsrep_provider"]                 = value_for_platform_family(
                                                                     "debian" => "/usr/lib/libgalera_smm.so",

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Installs Percona MySQL client and server"
 long_description  "Please refer to README.md"
-version           "0.15.5"
+version           "0.15.6"
 
 recipe "percona",                "Includes the client recipe to configure a client"
 recipe "percona::package_repo",  "Sets up the package repository and installs dependent packages"


### PR DESCRIPTION
On RHEL distros it's Percona-XtraDB-Cluster-55 intead of percona-xtradb-cluster-55, so I've updated attributes/default.rb. Without that, on RHEL distros you will get:

ERROR: package[percona-xtradb-cluster-55](percona::cluster line 31) had an error: Chef::Exceptions::Package: No version specified, and no candidate version available for percona-xtradb-cluster-55
