### PR TITLE
Fix XtraDB Cluster dependency and version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ cause, and we'll make reasonable efforts to improve support:
 * [apt](http://community.opscode.com/cookbooks/apt) Opscode LWRP Cookbook
 * [openssl](http://community.opscode.com/cookbooks/openssl) Opscode Cookbook
 * [yum](http://community.opscode.com/cookbooks/yum) Opscode LWRP Cookbook
+* [yum-epel] (https://supermarket.getchef.com/cookbooks/yum-epel) Opscode Cookbook
 
 ### Chef
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -159,7 +159,7 @@ unless attribute?(node["percona"]["backup"]["password"])
 end
 
 # XtraDB Cluster Settings
-default["percona"]["cluster"]["package"]                        = "percona-xtradb-cluster-55"
+default["percona"]["cluster"]["package"]                        = "Percona-XtraDB-Cluster-#{version.tr(".", "")}"
 default["percona"]["cluster"]["binlog_format"]                  = "ROW"
 default["percona"]["cluster"]["wsrep_provider"]                 = value_for_platform_family(
                                                                     "debian" => "/usr/lib/libgalera_smm.so",

--- a/metadata.rb
+++ b/metadata.rb
@@ -20,6 +20,7 @@ recipe "percona::monitoring", "Installs Percona monitoring plugins for Nagios"
 
 depends "apt", ">= 1.9"
 depends "yum", "~> 3.0"
+depends "yum-epel"
 depends "openssl"
 
 supports "debian"

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -28,6 +28,15 @@ when "rhel"
     action :remove
   end
 
+  # This is required for 'socat' per: http://www.percona.com/doc/percona-xtradb-cluster/5.6/installation/yum_repo.html
+  # not only for 5.6 but also 5.5 has this dependency.
+  include_recipe "yum-epel"
+
+  # This follows the originals posters workaround found here: https://bugs.launchpad.net/percona-toolkit/+bug/1031427
+  # The package dependency PITA is actually a bug in the XtraDB Cluster package and not toolkit hence it's
+  # inclusion here before the actual XtraDB Cluster package install.
+  package "Percona-Server-shared-compat" if platform_family?("rhel")
+
   package node["percona"]["cluster"]["package"]
 end
 


### PR DESCRIPTION
Added the ‘yum-epel’ cookbook dependency such that ‘socat’ can be
installed for XtraDB Cluster.
Made the XtraDB Cluster version install an attribute.
