### PR TITLE
percona::toolkit fails to install version 5.6

### DIFF
--- a/recipes/toolkit.rb
+++ b/recipes/toolkit.rb
@@ -8,7 +8,7 @@ include_recipe "percona::package_repo"
 # Workaround a bug in the RPM packaging of percona-toolkit. Otherwise, it'll
 #   try to pull in Percona-Server-shared-51, which will conflict with 5.5.
 # https://bugs.launchpad.net/percona-toolkit/+bug/1031427
-package "Percona-Server-shared-compat" if platform_family?("rhel")
+package "Percona-Server-shared-compat" if platform_family?("rhel") and /5\.[15]/ =~ node["percona"]["version"]
 
 package "percona-toolkit" do
   options "--force-yes" if platform_family?("debian")

--- a/spec/toolkit_spec.rb
+++ b/spec/toolkit_spec.rb
@@ -19,12 +19,32 @@ describe "percona::toolkit" do
   end
 
   describe "CentOS" do
-    let(:chef_run) do
-      env_options = { platform: "centos", version: "6.5" }
-      ChefSpec::Runner.new(env_options).converge(described_recipe)
+
+    describe "when `version` is 5.5" do
+      let(:chef_run) do
+        env_options = { platform: "centos", version: "6.5" }
+        ChefSpec::Runner.new(env_options) do |node|
+          node.set["percona"]["version"] = "5.5"
+        end.converge(described_recipe)
+      end
+
+      it { expect(chef_run).to install_package(centos_package) }
+      it { expect(chef_run).to install_package(ubuntu_package) }
+  
     end
 
-    it { expect(chef_run).to install_package(centos_package) }
-    it { expect(chef_run).to install_package(ubuntu_package) }
+    describe "when `version` is 5.6" do
+      let(:chef_run) do
+        env_options = { platform: "centos", version: "6.5" }
+        ChefSpec::Runner.new(env_options) do |node|
+          node.set["percona"]["version"] = "5.6"
+        end.converge(described_recipe)
+      end
+
+      it { expect(chef_run).to_not install_package(centos_package) }
+      it { expect(chef_run).to install_package(ubuntu_package) }
+  
+    end
+
   end
 end


### PR DESCRIPTION
It appears that when running percona::toolkit with node["percona"]["version"] == 5.6, then Chef fails to install correctly because the compat package fixes things for 5.1 and 5.5, but not 5.6. 

```
Recipe: percona::toolkit
  * package[Percona-Server-shared-compat] action install

================================================================================
Error executing action `install` on resource 'package[Percona-Server-shared-compat]'
================================================================================

Chef::Exceptions::Exec
----------------------
 returned 1, expected 0

Resource Declaration:
---------------------
# In /root/chef-solo/cookbooks-2/percona/recipes/toolkit.rb

 11: package "Percona-Server-shared-compat" if platform_family?("rhel")
 12:

Compiled Resource:
------------------
# Declared in /root/chef-solo/cookbooks-2/percona/recipes/toolkit.rb:11:in `from_file'

package("Percona-Server-shared-compat") do
  action :install
  retries 0
  retry_delay 2
  guard_interpreter :default
  package_name "Percona-Server-shared-compat"
  version "5.1.68-rel14.6.551.rhel6"
  timeout 900
  cookbook_name :percona
  recipe_name "toolkit"
end
```

Here is the output from an attempted manual install of Percona-Server-shared-compat: 

```
[root@db ~]# yum install Percona-Server-shared-compat.x86_64
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: mirror.team-cymru.org
 * extras: mirror.vcu.edu
 * updates: mirror.us.leaseweb.net
Setting up Install Process
Resolving Dependencies
--> Running transaction check
---> Package Percona-Server-shared-compat.x86_64 0:5.1.68-rel14.6.551.rhel6 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================================================================================
 Package   ArchVersion   RepositorySize
================================================================================================================================================
Installing:
 Percona-Server-shared-compat  x86_64  5.1.68-rel14.6.551.rhel6  percona  3.8 M

Transaction Summary
================================================================================================================================================
Install   1 Package(s)

Total size: 3.8 M
Installed size: 11 M
Is this ok [y/N]: y
Downloading Packages:
Running rpm_check_debug
Running Transaction Test


Transaction Check Error:
  file /usr/lib64/libmysqlclient.so.16.0.0 from install of Percona-Server-shared-compat-5.1.68-rel14.6.551.rhel6.x86_64 conflicts with file from package Percona-Server-shared-51-5.1.73-rel14.12.624.rhel6.x86_64
  file /usr/lib64/libmysqlclient_r.so.16.0.0 from install of Percona-Server-shared-compat-5.1.68-rel14.6.551.rhel6.x86_64 conflicts with file from package Percona-Server-shared-51-5.1.73-rel14.12.624.rhel6.x86_64

Error Summary
-------------
```

It appears that percona-toolkit installs fine without Percona-Server-shared-compat, at least for 5.6, so I propose that the recipe only installs the Percona-Server-shared-compat for the 5.1 and 5.5 Percona versions. 

Would there be other considerations that I have not accounted for? I'll submit a PR shortly. 

Thank you, 

jim80net
