### PR TITLE
Generate config file before setting up data dir. Make mysql_install_data use config

### DIFF
--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -82,7 +82,7 @@ end
 
 # install db to the data directory
 execute "setup mysql datadir" do
-  command "mysql_install_db --defaults-file=#{percona["main_config_file"]} --user=#{user}"
+  command "mysql_install_db --defaults-file=#{percona["main_config_file"]} --user=#{user}" # rubocop:disable LineLength
   not_if "test -f #{datadir}/mysql/user.frm"
   action :nothing
 end

--- a/spec/configure_server_spec.rb
+++ b/spec/configure_server_spec.rb
@@ -19,7 +19,7 @@ describe "percona::configure_server" do
       )
 
       resource = chef_run.template("/etc/mysql/my.cnf")
-      expect(resource).to notify("execute[setup mysql datadir]").to(:run).immediately
+      expect(resource).to notify("execute[setup mysql datadir]").to(:run).immediately  # rubocop:disable LineLength
       expect(resource).to notify("service[mysql]").to(:restart).immediately
     end
 
@@ -122,7 +122,7 @@ describe "percona::configure_server" do
       )
 
       resource = chef_run.template("/mysql/my.cnf")
-      expect(resource).to notify("execute[setup mysql datadir]").to(:run).immediately
+      expect(resource).to notify("execute[setup mysql datadir]").to(:run).immediately # rubocop:disable LineLength
       expect(resource).to notify("service[mysql]").to(:restart).immediately
     end
 
@@ -165,7 +165,7 @@ describe "percona::configure_server" do
       )
 
       resource = chef_run.template("/etc/my.cnf")
-      expect(resource).to notify("execute[setup mysql datadir]").to(:run).immediately
+      expect(resource).to notify("execute[setup mysql datadir]").to(:run).immediately # rubocop:disable LineLength
       expect(resource).to notify("service[mysql]").to(:restart).immediately
     end
   end


### PR DESCRIPTION
This is required if a few of the `innodb` values are modified (as per https://dev.mysql.com/doc/refman/5.6/en/mysql-install-db.html). `innodb_data_file_path` being one of the bigger ones.

Had to remove the ChefSpec `run_execute` call for datadir setup since it isn't registered anymore in the same way. I check for the notify at least. Let me know if there is a way I can ensure it actually does (or doesn't to test the `not_if`) get ran.
