### PR TITLE
Add in the ability to enable / disable performance_schema

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -145,6 +145,9 @@ default["percona"]["server"]["innodb_max_dirty_pages_pct"]      = 80
 default["percona"]["server"]["innodb_flush_method"]             = "O_DIRECT"
 default["percona"]["server"]["innodb_lock_wait_timeout"]        = 120
 
+# Performance Schema
+default["percona"]["server"]["performance_schema"] = false
+
 # Replication Settings
 default["percona"]["server"]["replication"]["read_only"]        = false
 default["percona"]["server"]["replication"]["host"]             = ""

--- a/templates/default/my.cnf.cluster.erb
+++ b/templates/default/my.cnf.cluster.erb
@@ -99,6 +99,12 @@ old_passwords = <%= @old_passwords %>
 bind-address = <%= node["percona"]["server"]["bind_address"] %>
 <% end %>
 
+# As of 5.6.6 performance_schema is enabled by default. This allows it to be explicitly turned on
+# or off as needed across all mysql versions
+<% if node["percona"]["server"]["performance_schema"] %>
+performance_schema=node["percona"]["server"]["performance_schema"]
+<% end %>
+
 #
 # * Fine Tuning
 #

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -83,6 +83,12 @@ bind-address = <%= node["percona"]["server"]["bind_address"] %>
 <% end %>
 #
 
+# As of 5.6.6 performance_schema is enabled by default. This allows it to be explicitly turned on
+# or off as needed across all mysql versions
+<% if node["percona"]["server"]["performance_schema"] %>
+performance_schema=node["percona"]["server"]["performance_schema"]
+<% end %>
+
 # * Fine Tuning
 #
 key_buffer = <%= node["percona"]["server"]["key_buffer"] %>


### PR DESCRIPTION
From MySQL 5.6.6 it was made enabled by default, while previously it was disabled. It has overhead to it that not everyone will desire, so turning it off for everyone by default in the cookbooks.
