### PR TITLE
Fixes root password configuration condition

### DIFF
--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -115,7 +115,7 @@ template percona["main_config_file"] do
   end
 end
 
-# now let's set the root password only if this is the initial install
+# now let's set the root password but only if it has not been set before
 unless node["percona"]["skip_passwords"]
   execute "Update MySQL root password" do
     root_pw = passwords.root_password


### PR DESCRIPTION
This PR fixes a problem with the only_if condition used before setting the root password.

The detection command now uses the `mysqladmin ping` which, as explained below, **always exits with 0** breaking idempotence (e.g. when running kitchen converge after a root password has been set).

> mysqladmin ping:
> Check whether the server is available. 
> The return status from mysqladmin is 0 if the server is running, 1 if it is not.
> This is 0 even in case of an error such as Access denied, because this means that the server is running but refused the connection, which is different from the server not running.

Test case proving current always-zero exit:

```
#!/usr/bin/env bash

OUTPUT=$(mysqladmin --user=root --password='' ping)
EXITCODE=$?
echo "$OUTPUT"
if [ "$EXITCODE" -ne 0 ]; then
    echo "command exited with non-zero $EXITCODE"
else
    echo "command exited with 0"
fi
```

Test case confirming PR fix:

```
#!/usr/bin/env bash

OUTPUT=$(mysql --user=root --password='' -e 'show databases;')
EXITCODE=$?
echo "$OUTPUT"
if [ "$EXITCODE" -ne 0 ]; then
    echo "command exited with non-zero $EXITCODE"
else
    echo "mysqladmin exited with 0"
fi
```
