### PR TITLE
Remove deprecated chef features

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,3 @@
 source 'https://supermarket.chef.io'
 
 metadata
-
-group :integration do
-  cookbook 'test', path: 'test/fixtures/cookbooks/test'
-end

--- a/README.md
+++ b/README.md
@@ -54,17 +54,16 @@ cause, and we'll make reasonable efforts to improve support:
 
 ### Cookbooks
 
-* [apt](https://supermarket.getchef.com/cookbooks/apt) Chef LWRP Cookbook
+* [build-essential](https://github.com/chef-cookbooks/build-essential)
 * [openssl](https://supermarket.getchef.com/cookbooks/openssl) Chef Cookbook
-* [yum](https://supermarket.getchef.com/cookbooks/yum) Chef LWRP Cookbook
 * [yum-epel](https://supermarket.getchef.com/cookbooks/yum-epel) Chef LWRP Cookbook
 
 ### Chef
 
-This cookbook requires Chef >= 11.14.2 due to the use of the `sensitive` attribute for some resources.
+This cookbook requires Chef >= 13.4 due to the use of chef-vault.
 
 We aim to test the most recent releases of Chef. You can view
-the [currently tested versions](https://github.com/phlipper/chef-percona/blob/master/.travis.yml).
+the [currently tested versions](https://github.com/sous-chefs/percona/blob/master/.travis.yml).
 (Feel free to submit a pull request if they're out of date!)
 
 
@@ -88,7 +87,7 @@ This cookbook installs the Percona MySQL components if not present, and pulls up
 
 ### Encrypted Passwords
 
-This cookbook requires [Encrypted Data Bags](http://wiki.opscode.com/display/chef/Encrypted+Data+Bags). If you forget to use them or do not use a node attribute to overwrite them empty passwords will be used.
+This cookbook requires [Encrypted Data Bags](https://docs.chef.io/data_bags.html#encrypt-a-data-bag-item). If you forget to use them or do not use a node attribute to overwrite them empty passwords will be used.
 
 To use encrypted passwords, you must create an encrypted data bag. This cookbook assumes a data bag named `passwords`, but you can override the name using the `node[:percona][:encrypted_data_bag]` attribute.  You can also optionally specify a data bag secret file to be loaded for the secret key using the `node[:percona][:encrypted_data_bag_secret_file]` attribute.
 
@@ -559,7 +558,7 @@ In no particular order:
 
 ## Contributors
 
-Many thanks go to the following [contributors](https://github.com/phlipper/chef-percona/graphs/contributors) who have helped to make this cookbook even better:
+Many thanks go to the following [contributors](https://github.com/sous-chefs/percona/graphs/contributors) who have helped to make this cookbook even better:
 
 * **[@jagcrete](https://github.com/jagcrete)**
     * configurable keyserver

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,7 @@ long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url        'https://github.com/phlipper/chef-percona'
 issues_url        'https://github.com/phlipper/chef-percona/issues'
 version           '0.16.4'
+chef_version      '>= 13.4'
 
 depends 'build-essential'
 depends 'openssl'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,6 @@ version           '0.16.4'
 depends 'build-essential'
 depends 'openssl'
 depends 'yum-epel'
-depends 'chef-vault'
 
 supports 'debian'
 supports 'ubuntu'

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -11,7 +11,7 @@ if node['percona']['cluster']['wsrep_sst_receive_interface']
   sst_port = node['percona']['cluster']['wsrep_sst_receive_port']
   ip = Percona::ConfigHelper.bind_to(node, sst_interface)
   address = "#{ip}:#{sst_port}"
-  node.set['percona']['cluster']['wsrep_sst_receive_address'] = address
+  node.default['percona']['cluster']['wsrep_sst_receive_address'] = address
 end
 
 # set default package attributes

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -24,8 +24,13 @@ unless node['percona']['selinux_module_url'].nil? || node['percona']['selinux_mo
   end
 end
 
-# install chef-vault if needed
-include_recipe 'chef-vault' if node['percona']['use_chef_vault']
+if node['percona']['use_chef_vault']
+  chef_gem 'chef-vault' do
+    compile_time true if respond_to?(:compile_time)
+  end
+
+  require 'chef-vault'
+end
 
 # construct an encrypted passwords helper -- giving it the node and bag name
 passwords = EncryptedPasswords.new(node, percona['encrypted_data_bag'])

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -24,14 +24,6 @@ unless node['percona']['selinux_module_url'].nil? || node['percona']['selinux_mo
   end
 end
 
-if node['percona']['use_chef_vault']
-  chef_gem 'chef-vault' do
-    compile_time true if respond_to?(:compile_time)
-  end
-
-  require 'chef-vault'
-end
-
 # construct an encrypted passwords helper -- giving it the node and bag name
 passwords = EncryptedPasswords.new(node, percona['encrypted_data_bag'])
 

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -7,7 +7,6 @@ return unless node['percona']['use_percona_repos']
 
 case node['platform_family']
 when 'debian'
-  include_recipe 'apt'
 
   # Pin this repo as to avoid upgrade conflicts with distribution repos.
   apt_preference '00percona' do
@@ -26,7 +25,6 @@ when 'debian'
   end
 
 when 'rhel'
-  include_recipe 'yum'
 
   yum_repository 'percona' do
     description node['percona']['yum']['description']

--- a/recipes/replication.rb
+++ b/recipes/replication.rb
@@ -18,7 +18,7 @@ template replication_sql do
   mode '0600'
   sensitive true
   only_if do
-    (server['replication']['host'] != '' || server['role'].include?('master')) && !::File.exists?(replication_sql)
+    (server['replication']['host'] != '' || server['role'].include?('master')) && !::File.exist?(replication_sql)
   end
 end
 

--- a/spec/access_grants_spec.rb
+++ b/spec/access_grants_spec.rb
@@ -7,7 +7,7 @@ describe 'percona::access_grants' do
 
   let(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
-      node.set['percona']['server']['root_password'] = 's3kr1t'
+      node.default['percona']['server']['root_password'] = 's3kr1t'
     end.converge(described_recipe)
   end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -30,7 +30,7 @@ describe 'percona::client' do
     describe 'Ubuntu' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set['percona']['client']['package_action'] = 'upgrade'
+          node.default['percona']['client']['package_action'] = 'upgrade'
         end.converge(described_recipe)
       end
 
@@ -44,7 +44,7 @@ describe 'percona::client' do
       let(:chef_run) do
         env_options = { platform: 'centos', version: '6.5' }
         ChefSpec::SoloRunner.new(env_options) do |node|
-          node.set['percona']['client']['package_action'] = 'upgrade'
+          node.default['percona']['client']['package_action'] = 'upgrade'
         end.converge(described_recipe)
       end
 

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -22,7 +22,7 @@ describe 'percona::cluster' do
   describe 'version 5.5' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['percona']['version'] = '5.5'
+        node.default['percona']['version'] = '5.5'
       end.converge(described_recipe)
     end
 
@@ -48,7 +48,7 @@ describe 'percona::cluster' do
       let(:chef_run) do
         env_options = { platform: 'centos', version: '6.5' }
         ChefSpec::SoloRunner.new(env_options) do |node|
-          node.set['percona']['version'] = '5.5'
+          node.default['percona']['version'] = '5.5'
         end.converge(described_recipe)
       end
 
@@ -70,7 +70,7 @@ describe 'percona::cluster' do
   describe 'version 5.6' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['percona']['version'] = '5.6'
+        node.default['percona']['version'] = '5.6'
       end.converge(described_recipe)
     end
 
@@ -96,7 +96,7 @@ describe 'percona::cluster' do
       let(:chef_run) do
         env_options = { platform: 'centos', version: '6.5' }
         ChefSpec::SoloRunner.new(env_options) do |node|
-          node.set['percona']['version'] = '5.6'
+          node.default['percona']['version'] = '5.6'
         end.converge(described_recipe)
       end
 

--- a/spec/configure_server_spec.rb
+++ b/spec/configure_server_spec.rb
@@ -89,13 +89,13 @@ describe 'percona::configure_server' do
   describe 'subsequent runs' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['percona']['main_config_file'] = '/mysql/my.cnf'
-        node.set['percona']['server']['root_password'] = 's3kr1t'
-        node.set['percona']['server']['debian_password'] = 'd3b1an'
-        node.set['percona']['server']['performance_schema'] = true
-        node.set['percona']['conf']['mysqld']['datadir'] = '/mysql/data'
-        node.set['percona']['conf']['mysqld']['tmpdir'] = '/mysql/tmp'
-        node.set['percona']['conf']['mysqld']['includedir'] = '/mysql/conf.d'
+        node.default['percona']['main_config_file'] = '/mysql/my.cnf'
+        node.default['percona']['server']['root_password'] = 's3kr1t'
+        node.default['percona']['server']['debian_password'] = 'd3b1an'
+        node.default['percona']['server']['performance_schema'] = true
+        node.default['percona']['conf']['mysqld']['datadir'] = '/mysql/data'
+        node.default['percona']['conf']['mysqld']['tmpdir'] = '/mysql/tmp'
+        node.default['percona']['conf']['mysqld']['includedir'] = '/mysql/conf.d'
       end.converge(described_recipe)
     end
 
@@ -208,7 +208,7 @@ describe 'percona::configure_server' do
   describe 'custom slow query log directory' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['percona']['server']['slow_query_logdir'] = '/var/log/slowq'
+        node.default['percona']['server']['slow_query_logdir'] = '/var/log/slowq'
       end.converge(described_recipe)
     end
 
@@ -261,7 +261,7 @@ describe 'percona::configure_server' do
   describe '`chef-vault` support' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['percona']['use_chef_vault'] = true
+        node.default['percona']['use_chef_vault'] = true
       end.converge(described_recipe)
     end
 

--- a/spec/replication_spec.rb
+++ b/spec/replication_spec.rb
@@ -8,8 +8,8 @@ describe 'percona::replication' do
   describe 'without replication configured' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['percona']['server']['role'] = []
-        node.set['percona']['server']['replication']['host'] = ''
+        node.default['percona']['server']['role'] = []
+        node.default['percona']['server']['replication']['host'] = ''
       end.converge(described_recipe)
     end
 
@@ -28,8 +28,8 @@ describe 'percona::replication' do
   describe 'with replication configured' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['percona']['server']['role'] = ['master']
-        node.set['percona']['server']['replication']['password'] = 's3kr1t'
+        node.default['percona']['server']['role'] = ['master']
+        node.default['percona']['server']['replication']['password'] = 's3kr1t'
       end.converge(described_recipe)
     end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -53,7 +53,7 @@ describe 'percona::server' do
   describe 'when `skip_configure` is true' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['percona']['skip_configure'] = true
+        node.default['percona']['skip_configure'] = true
       end.converge(described_recipe)
     end
 
@@ -63,7 +63,7 @@ describe 'percona::server' do
   describe 'when `skip_passwords` is true' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
-        node.set['percona']['skip_passwords'] = true
+        node.default['percona']['skip_passwords'] = true
       end.converge(described_recipe)
     end
 
@@ -75,7 +75,7 @@ describe 'percona::server' do
     describe 'Ubuntu' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new do |node|
-          node.set['percona']['server']['package_action'] = 'upgrade'
+          node.default['percona']['server']['package_action'] = 'upgrade'
         end.converge(described_recipe)
       end
 
@@ -86,7 +86,7 @@ describe 'percona::server' do
       let(:chef_run) do
         env_options = { platform: 'centos', version: '6.5' }
         ChefSpec::SoloRunner.new(env_options) do |node|
-          node.set['percona']['server']['package_action'] = 'upgrade'
+          node.default['percona']['server']['package_action'] = 'upgrade'
         end.converge(described_recipe)
       end
 

--- a/spec/ssl_spec.rb
+++ b/spec/ssl_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'percona::ssl' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
-      node.set['percona']['encrypted_data_bag'] = 'test-bag'
-      node.set['percona']['server']['role'] = %w(master slave)
+      node.default['percona']['encrypted_data_bag'] = 'test-bag'
+      node.default['percona']['server']['role'] = %w(master slave)
     end.converge(described_recipe)
   end
 

--- a/spec/toolkit_spec.rb
+++ b/spec/toolkit_spec.rb
@@ -20,7 +20,7 @@ describe 'percona::toolkit' do
       let(:chef_run) do
         env_options = { platform: 'centos', version: '6.5' }
         ChefSpec::SoloRunner.new(env_options) do |node|
-          node.set['percona']['version'] = '5.5'
+          node.default['percona']['version'] = '5.5'
         end.converge(described_recipe)
       end
 
@@ -33,7 +33,7 @@ describe 'percona::toolkit' do
       let(:chef_run) do
         env_options = { platform: 'centos', version: '6.5' }
         ChefSpec::SoloRunner.new(env_options) do |node|
-          node.set['percona']['version'] = '5.6'
+          node.default['percona']['version'] = '5.6'
         end.converge(described_recipe)
       end
 


### PR DESCRIPTION
Use built in apt and yum resources as of Chef 12.9
Convert to gem installation for chef-vault, remove from metadata
Remove use of node.set in all recipes and specs