### PR TITLE
Update Percona Signing Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+* Many other changes
+
+### Fixed
+
+* Use latest percona GPG keys for yum repo. See [New Percona Package Signing Key Requires Update on RHEL and CentOS](https://www.percona.com/blog/2019/02/05/new-percona-package-signing-key-requires-update-on-rhel-and-centos/)
+
+## [0.16.1] - 2015-06-03
+
+* Many changes
+
+[Unreleased]: https://github.com/sous-chefs/percona/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/sous-chefs/percona/compare/v0.16.0...v0.16.1

--- a/Dangerfile
+++ b/Dangerfile
@@ -20,7 +20,7 @@ warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
 if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  fail 'Please include a [CHANGELOG](https://github.com/sous-chefs/line-cookbook/blob/master/CHANGELOG.md) entry.'
+  fail 'Please include a [CHANGELOG](https://github.com/sous-chefs/percona/blob/master/CHANGELOG.md) entry.'
 end
 
 # A sanity check for tests.

--- a/Dangerfile
+++ b/Dangerfile
@@ -19,7 +19,7 @@ fail 'Please provide a summary of your Pull Request.' if github.pr_body.length <
 warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
-if !git.modified_files.include?('CHANGELOG.md') && code_changes?
+if !git.added_files.include?('CHANGELOG.md') && !git.modified_files.include?('CHANGELOG.md') && code_changes?
   fail 'Please include a [CHANGELOG](https://github.com/sous-chefs/percona/blob/master/CHANGELOG.md) entry.'
 end
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We provide an expanding set of tests against the following 64-bit platforms:
 - Ubuntu 12.04 LTS
 - Ubuntu 14.04 LTS
 
-Although we don't test against all possible platform verions, we expect
+Although we don't test against all possible platform versions, we expect
 the following to be supported. Please submit an issue if this is not the
 cause, and we'll make reasonable efforts to improve support:
 
@@ -472,7 +472,10 @@ default["percona"]["plugins_packages"] = %w[percona-nagios-plugins percona-zabbi
 ```ruby
 default["percona"]["yum"]["description"] = "Percona Packages"
 default["percona"]["yum"]["baseurl"]     = "http://repo.percona.com/centos/#{pversion}/os/#{arch}/"
-default["percona"]["yum"]["gpgkey"]      = "http://www.percona.com/downloads/RPM-GPG-KEY-percona"
+default["percona"]["yum"]["gpgkey"]      = [
+  'https://repo.percona.com/yum/PERCONA-PACKAGING-KEY',
+  'https://repo.percona.com/yum/RPM-GPG-KEY-Percona',
+]
 default["percona"]["yum"]["gpgcheck"]    = true
 default["percona"]["yum"]["sslverify"]   = true
 ```

--- a/attributes/package_repo.rb
+++ b/attributes/package_repo.rb
@@ -17,6 +17,9 @@ default['percona']['apt']['uri'] = 'http://repo.percona.com/apt'
 
 default['percona']['yum']['description'] = 'Percona Packages'
 default['percona']['yum']['baseurl'] = "http://repo.percona.com/centos/#{pversion}/os/#{arch}/"
-default['percona']['yum']['gpgkey'] = 'https://www.percona.com/downloads/RPM-GPG-KEY-percona'
+default['percona']['yum']['gpgkey'] = [
+  'https://repo.percona.com/yum/PERCONA-PACKAGING-KEY',
+  'https://repo.percona.com/yum/RPM-GPG-KEY-Percona',
+]
 default['percona']['yum']['gpgcheck'] = true
 default['percona']['yum']['sslverify'] = true


### PR DESCRIPTION
### Description

On December 28th 2018, Percona changed their signing key for new packages.
This means packages cannot be downloaded via Yum unless the key URL is updated.

There are still packages available on the repository that are signed with the old key,
so we need to have both keys available.

See https://www.percona.com/blog/2019/02/05/new-percona-package-signing-key-requires-update-on-rhel-and-centos/

I've struggled to run the tests for this project - chefspec fatal errors with the following message but that directory doesn't exist:
```
An error occurred in a `before(:suite)` hook.
Failure/Error: raise NotACookbook.new(path)

Berkshelf::NotACookbook:
  The resource at '/Users/kevans/Repositories/chef/percona/test/fixtures/cookbooks/test' does not appear to be a valid cookbook. Does it have a metadata.rb?
```

Similar PR raised at https://github.com/chef-cookbooks/yum-percona/pull/3 and it works there :)

### Issues Resolved

None raised so far

### Contribution Check List

- [ ] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable