### PR TITLE
Fix idempotency issues with find_password method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the percona cookbook.
 ### Fixed
 
 - Fix debian_password as a string for testing
+- Fix idempotency issues with find_password method
 
 ## 0.17.1 - 2020-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the percona cookbook.
 
+## Unreleased
+
+### Fixed
+
+- Fix debian_password as a string for testing
+
 ## 0.17.1 - 2020-05-14
 
 - resolved cookstyle error: recipes/access_grants.rb:28:40 convention: `Layout/TrailingWhitespace`

--- a/libraries/passwords.rb
+++ b/libraries/passwords.rb
@@ -20,7 +20,7 @@ class Chef
         # load password from the vault
         pwds = ChefVault::Item.load(bag, item) if vault
         # load the encrypted data bag item, using a secret if specified
-        pwds = data_bag_item(@bag, item, secret) unless vault
+        pwds = Chef::EncryptedDataBagItem.load(@bag, item, secret) unless vault # rubocop:disable ChefModernize/DatabagHelpers
         # now, let's look for the user password
         password = pwds[user]
       rescue

--- a/test/fixtures/cookbooks/test/recipes/server-56.rb
+++ b/test/fixtures/cookbooks/test/recipes/server-56.rb
@@ -1,7 +1,7 @@
 node.default['percona']['apt']['keyserver'] = 'hkp://pgp.mit.edu:80'
 node.default['percona']['version'] = '5.6'
 node.default['percona']['server']['datadir'] = '/tmp/mysql'
-node.default['percona']['server']['debian_password'] = d3b1an
+node.default['percona']['server']['debian_password'] = 'd3b1an'
 node.default['percona']['server']['jemalloc'] = true
 node.default['percona']['server']['root_password'] = 'r00t'
 

--- a/test/fixtures/cookbooks/test/recipes/server-57.rb
+++ b/test/fixtures/cookbooks/test/recipes/server-57.rb
@@ -1,7 +1,7 @@
 node.default['percona']['apt']['keyserver'] = 'hkp://pgp.mit.edu:80'
 node.default['percona']['version'] = '5.7'
 node.default['percona']['server']['datadir'] = '/tmp/mysql'
-node.default['percona']['server']['debian_password'] = d3b1an
+node.default['percona']['server']['debian_password'] = 'd3b1an'
 node.default['percona']['server']['jemalloc'] = true
 node.default['percona']['server']['root_password'] = 'r00t'
 


### PR DESCRIPTION
### Description

This partially reverts #425 and restores use of ``Chef::EncryptedDataBagItem.load`` in the ``EncryptedPasswords`` class. Without this, data bags were not being properly accessed via this class.

Longer term this will fix be migrated into a proper module library as a resource cookbook.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable