### PR TITLE
Add devel package attribute to client recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           - 'client-56'
           - 'client-57'
           - 'client-80'
+          - 'devel-56'
+          - 'devel-57'
+          - 'devel-80'
           - 'server-56'
           - 'server-57'
           - 'server-80'
@@ -67,6 +70,8 @@ jobs:
           - os: centos-8
             suite: client-56
           - os: centos-8
+            suite: devel-56
+          - os: centos-8
             suite: server-56
           - os: centos-8
             suite: source-56
@@ -74,6 +79,8 @@ jobs:
             suite: replication-56
           - os: debian-10
             suite: client-56
+          - os: debian-10
+            suite: devel-56
           - os: debian-10
             suite: server-56
           - os: debian-10
@@ -82,6 +89,8 @@ jobs:
             suite: replication-56
           - os: ubuntu-2004
             suite: client-56
+          - os: ubuntu-2004
+            suite: devel-56
           - os: ubuntu-2004
             suite: server-56
           - os: ubuntu-2004

--- a/README.md
+++ b/README.md
@@ -113,10 +113,14 @@ Example: "passwords" data bag - this example assumes that `node['percona']['serv
 
 Above shows the encrypted password in the data bag. Check out the `encrypted_data_bag_secret` setting in `knife.rb` to setup your data bag secret during bootstrapping.
 
+### Install client development package
+
+To install the package including header files needed to compile software using the client library (`percona-server-devel` on Centos and `libperconaserverclient-dev` on Debian), set `node['percona']['client']['install_devel_package']` to `true`. This will add those packages to the list to be installed when running the `percona::client` recipe. This attribute is disabled by default.
+
 ### Replication over SSL
 
-To enable SSL based replication, you will need to flip the attribute `node['percona']['server']['replication']['ssl_enabled']` to `true` and add a new data_bag item
-to the percona encrypted data_bag (see`node['percona']['encrypted_data_bag']` attribute) with the id `ssl_replication` ( see `node['percona']['encrypted_data_bag_item_ssl_replication']` attribute) that contains this data:
+To enable SSL based replication, you will need to flip the attribute `node['percona']['server']['replication']['ssl_enabled']` to `true` and add a new data\_bag item
+to the percona encrypted data\_bag (see`node['percona']['encrypted_data_bag']` attribute) with the id `ssl_replication` ( see `node['percona']['encrypted_data_bag_item_ssl_replication']` attribute) that contains this data:
 
 ```javascript
 {

--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -6,3 +6,4 @@
 # install vs. upgrade packages
 default['percona']['client']['package_action'] = 'install'
 default['percona']['client']['packages'] = []
+default['percona']['client']['install_devel_package'] = false

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -68,6 +68,58 @@ suites:
       inputs:
         version: '8.0'
 
+  - name: devel-56
+    run_list:
+      - recipe[test::client]
+    attributes:
+      percona:
+        version: '5.6'
+        client:
+          install_devel_package: true
+    verifier:
+      controls:
+        - client
+        - toolkit
+      inputs:
+        version: '5.6'
+        devel: true
+    excludes:
+      - centos-8
+      - debian-10
+      - ubuntu-20.04
+
+  - name: devel-57
+    run_list:
+      - recipe[test::client]
+    attributes:
+      percona:
+        version: '5.7'
+        client:
+          install_devel_package: true
+    verifier:
+      controls:
+        - client
+        - toolkit
+      inputs:
+        version: '5.7'
+        devel: true
+
+  - name: devel-80
+    run_list:
+      - recipe[test::client]
+    attributes:
+      percona:
+        version: '8.0'
+        client:
+          install_devel_package: true
+    verifier:
+      controls:
+        - client
+        - toolkit
+      inputs:
+        version: '8.0'
+        devel: true
+
   - name: server-56
     run_list:
       - recipe[test::server]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -27,6 +27,25 @@ module Percona
         end
       end
 
+      def percona_devel_package
+        case node['platform_family']
+        when 'rhel'
+          if node['percona']['version'].to_i >= 8
+            'percona-server-devel'
+          else
+            "Percona-Server-devel-#{percona_version}"
+          end
+        when 'debian'
+          if node['percona']['version'].to_i >= 8
+            'libperconaserverclient21-dev'
+          elsif node['percona']['version'] == '5.7'
+            'libperconaserverclient20-dev'
+          elsif node['percona']['version'] == '5.6'
+            'libperconaserverclient18.1-dev'
+          end
+        end
+      end
+
       def percona_server_package
         if node['percona']['version'].to_i >= 8
           'percona-server-server'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -6,6 +6,7 @@
 include_recipe 'percona::package_repo'
 
 pkgs = node['percona']['client']['packages'].empty? ? percona_client_packages : node['percona']['client']['packages']
+pkgs << percona_devel_package if node['percona']['client']['install_devel_package']
 
 package pkgs do
   action node['percona']['client']['package_action'].to_sym

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -13,6 +13,10 @@ describe 'percona::client' do
         expect(chef_run).to install_package 'percona-server-client'
       end
 
+      it do
+        expect(chef_run).to_not install_package 'libperconaserverclient21-dev'
+      end
+
       context 'version 5.7' do
         override_attributes['percona']['version'] = '5.7'
         it do
@@ -33,6 +37,10 @@ describe 'percona::client' do
 
       it do
         expect(chef_run).to install_package 'percona-server-client'
+      end
+
+      it do
+        expect(chef_run).to_not install_package 'percona-server-devel'
       end
 
       context 'version 5.7' do
@@ -67,6 +75,26 @@ describe 'percona::client' do
 
       it do
         expect(chef_run).to upgrade_package 'percona-server-client'
+      end
+    end
+  end
+
+  describe 'when `install_devel_package` is `true`' do
+    context 'Ubuntu' do
+      platform 'ubuntu'
+      override_attributes['percona']['client']['install_devel_package'] = true
+
+      it do
+        expect(chef_run).to install_package %w(percona-server-client libperconaserverclient21-dev)
+      end
+    end
+
+    context 'CentOS' do
+      platform 'centos'
+      override_attributes['percona']['client']['install_devel_package'] = true
+
+      it do
+        expect(chef_run).to install_package %w(percona-server-client percona-server-devel)
       end
     end
   end

--- a/test/integration/inspec/controls/client_spec.rb
+++ b/test/integration/inspec/controls/client_spec.rb
@@ -1,5 +1,6 @@
 version = input('version')
 type = input('type')
+devel = input('devel')
 
 control 'client' do
   desc 'Ensure Percona clients are installed.'
@@ -53,6 +54,34 @@ control 'client' do
       end
     end
 
+    if devel == true
+      if version.to_i >= 8
+        describe package 'libperconaserverclient21-dev' do
+          it { should be_installed }
+        end
+      elsif version == '5.7'
+        describe package 'libperconaserverclient20-dev' do
+          it { should be_installed }
+        end
+      elsif version == '5.6'
+        describe package 'libperconaserverclient18.1-dev' do
+          it { should be_installed }
+        end
+      end
+    elsif version.to_i >= 8
+      describe package 'libperconaserverclient21-dev' do
+        it { should_not be_installed }
+      end
+    elsif version == '5.7'
+      describe package 'libperconaserverclient20-dev' do
+        it { should_not be_installed }
+      end
+    elsif version == '5.6'
+      describe package 'libperconaserverclient18.1-dev' do
+        it { should_not be_installed }
+      end
+    end
+
   else
     describe yum.repo 'percona' do
       it { should exist }
@@ -83,6 +112,26 @@ control 'client' do
         it { should be_installed }
       end
     end
+
+    if devel == true
+      if version.to_i >= 8
+        describe package 'percona-server-devel' do
+          it { should be_installed }
+        end
+      else
+        describe package "Percona-Server-devel-#{version.tr('.', '')}" do
+          it { should be_installed }
+        end
+      end
+    else
+      describe package "Percona-Server-devel-#{version.tr('.', '')}" do
+        it { should_not be_installed }
+      end
+      describe package 'percona-server-devel' do
+        it { should_not be_installed }
+      end
+    end
+
   end
 
   describe command 'mysql --version' do


### PR DESCRIPTION
### Description 

Adds the attribute `['percona']['client']['install_devel_package']` that when set to `true` will install the development package for percona client (`percona-server-devel` on Centos and `libperconaserverclient-dev` on Debian). By default the attribute is `false`.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable