### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the percona cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: resources/mysql_database.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/mysql_user.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 2.1.0 - *2021-01-19*
 
 - Fix error when granting multi-word privileges (ex. `REPLICATION CLIENT`) to users through `percona_mysql_user`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the percona cookbook.
 
 ## Unreleased
 
+- resolved cookstyle error: metadata.rb:11:1 refactor: `Chef/Modernize/DependsOnOpensslCookbook`
+- resolved cookstyle error: metadata.rb:13:1 refactor: `Chef/Modernize/DependsOnChefVaultCookbook`
 - resolved cookstyle error: resources/mysql_database.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 - resolved cookstyle error: resources/mysql_user.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 2.1.0 - *2021-01-19*

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,10 +7,7 @@ source_url        'https://github.com/sous-chefs/chef-percona'
 issues_url        'https://github.com/sous-chefs/chef-percona/issues'
 version           '2.1.0'
 chef_version      '>= 13.0'
-
-depends 'openssl'
 depends 'yum-epel'
-depends 'chef-vault'
 depends 'line'
 
 supports 'centos'

--- a/resources/mysql_database.rb
+++ b/resources/mysql_database.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 provides :percona_mysql_database
+unified_mode true
 
 include Percona::Cookbook::Helpers
 include Percona::Cookbook

--- a/resources/mysql_user.rb
+++ b/resources/mysql_user.rb
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 provides :percona_mysql_user
+unified_mode true
 
 include Percona::Cookbook::Helpers
 include Percona::Cookbook


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.20.0 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with metadata.rb

 - 11:1 refactor: `Chef/Modernize/DependsOnOpensslCookbook` - Don't depend on the openssl cookbook which was made obsolete by Chef Infra Client 14.4. All openssl resource are now included directly in Chef Infra Client. (https://docs.chef.io/workstation/cookstyle/chef_modernize_dependsonopensslcookbook)
 - 13:1 refactor: `Chef/Modernize/DependsOnChefVaultCookbook` - Don't depend on the chef-vault cookbook made obsolete by Chef Infra Client 16.0. The chef-vault gem and helpers are now included in Chef Infra Client itself. (https://docs.chef.io/workstation/cookstyle/chef_modernize_dependsonchefvaultcookbook)