### PR TITLE
Use dnf_module resource from yum cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the percona cookbook.
 
 ## Unreleased
 
+- Use `dnf_module` resource from `yum` cookbook instead of manually disabling module
+
 ## 3.0.0 - *2021-09-17*
 
 - Chef 17 updates: enable `unified_mode` on all resources

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,14 +3,14 @@ driver:
   name: dokken
   # because Docker and SystemD/Upstart
   privileged: true
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
-  env: [CHEF_LICENSE=accept]
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_license: accept-no-persist
 
 platforms:
   - name: debian-9

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,7 @@ issues_url        'https://github.com/sous-chefs/chef-percona/issues'
 version           '3.0.0'
 chef_version      '>= 16.0'
 
+depends 'yum'
 depends 'yum-epel'
 depends 'line'
 

--- a/recipes/package_repo.rb
+++ b/recipes/package_repo.rb
@@ -33,9 +33,9 @@ when 'debian'
   end
 
 when 'rhel'
-  execute 'dnf -y module disable mysql' do
+  dnf_module 'mysql' do
+    action :disable
     only_if { node['platform_version'].to_i >= 8 }
-    not_if 'dnf module list mysql | grep -q "^mysql.*\[x\]"'
   end
 
   yum_repository 'percona' do

--- a/spec/package_repo_spec.rb
+++ b/spec/package_repo_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe 'percona::package_repo' do
-  before do
-    stub_command('dnf module list mysql | grep -q "^mysql.*\\[x\\]"')
-  end
-
   context 'ubuntu' do
     platform 'ubuntu'
 
@@ -45,6 +41,10 @@ describe 'percona::package_repo' do
 
   context 'centos' do
     platform 'centos'
+
+    it do
+      expect(chef_run).to disable_dnf_module('mysql')
+    end
 
     it do
       expect(chef_run).to create_yum_repository('percona').with(


### PR DESCRIPTION
# Description

Currently this cookbook manually shells out to disable the `mysql` module. The yum cookbook now has a resource for this, so this switches to using that instead.

## Issues Resolved

(none)

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
