### PR TITLE
Remove myisam_repair_threads for < 5.7 as it's been deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,75 +8,72 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
+    permissions:
+      actions: write
+      checks: write
+      pull-requests: write
+      statuses: write
+      issues: write
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
-          - 'debian-9'
-          - 'debian-10'
-          - 'centos-7'
-          - 'centos-8'
-          - 'ubuntu-1804'
-          - 'ubuntu-2004'
+          - almalinux-8
+          - centos-7
+          - centos-stream-8
+          - debian-10
+          - debian-11
+          - rockylinux-8
+          - ubuntu-1804
+          - ubuntu-2004
         suite:
-          - 'client-56'
-          - 'client-57'
-          - 'client-80'
-          - 'devel-56'
-          - 'devel-57'
-          - 'devel-80'
-          - 'server-56'
-          - 'server-57'
-          - 'server-80'
-          - 'source-56'
-          - 'source-57'
-          - 'source-80'
-          - 'replication-56'
-          - 'replication-57'
-          - 'replication-80'
-          - 'resources-56'
-          - 'resources-57'
-          - 'resources-80'
+          - client-56
+          - client-57
+          - client-80
+          - devel-56
+          - devel-57
+          - devel-80
+          - server-56
+          - server-57
+          - server-80
+          - source-56
+          - source-57
+          - source-80
+          - replication-56
+          - replication-57
+          - replication-80
+          - resources-56
+          - resources-57
+          - resources-80
         exclude:
-          - os: centos-8
+          - os: almalinux-8
             suite: client-56
-          - os: centos-8
+          - os: almalinux-8
             suite: devel-56
-          - os: centos-8
+          - os: almalinux-8
             suite: server-56
-          - os: centos-8
+          - os: almalinux-8
             suite: source-56
-          - os: centos-8
+          - os: almalinux-8
             suite: replication-56
-          - os: centos-8
+          - os: almalinux-8
+            suite: resources-56
+          - os: centos-stream-8
+            suite: client-56
+          - os: centos-stream-8
+            suite: devel-56
+          - os: centos-stream-8
+            suite: server-56
+          - os: centos-stream-8
+            suite: source-56
+          - os: centos-stream-8
+            suite: replication-56
+          - os: centos-stream-8
             suite: resources-56
           - os: debian-10
             suite: client-56
@@ -89,6 +86,30 @@ jobs:
           - os: debian-10
             suite: replication-56
           - os: debian-10
+            suite: resources-56
+          - os: debian-11
+            suite: client-56
+          - os: debian-11
+            suite: devel-56
+          - os: debian-11
+            suite: server-56
+          - os: debian-11
+            suite: source-56
+          - os: debian-11
+            suite: replication-56
+          - os: debian-11
+            suite: resources-56
+          - os: rockylinux-8
+            suite: client-56
+          - os: rockylinux-8
+            suite: devel-56
+          - os: rockylinux-8
+            suite: server-56
+          - os: rockylinux-8
+            suite: source-56
+          - os: rockylinux-8
+            suite: replication-56
+          - os: rockylinux-8
             suite: resources-56
           - os: ubuntu-2004
             suite: client-56

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This file is used to list changes made in each version of the percona cookbook.
 
 ## Unreleased
 
+- Remove `myisam_repair_threads` for < 5.7 as it's been deprecated
+- Remove delivery and move to calling RSpec directly via a reusable workflow
+- Update tested platforms
+- Add support to Alma Linux & Rocky Linux
+- Update default encoding when using 8.0 to `utf8mb3` to fix idempotency issues
+- Fix management of server `my.cnf`
+  - Set `manage_symlink_source` to `false` and set `force_unlink` to `true` to fix idempotency on Debian based systems
+- Fix issue when testing on Debian dokken images by removing mailutils (and thus mysql-common)
+
 ## 3.1.3 - *2022-02-17*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 We provide an expanding set of tests against the following 64-bit platforms which match what upstream supports:
 
 - CentOS 7+
-- Debian 9+
+- Debian 10+
 - Ubuntu 18.04+ LTS
 
 ### Cookbooks

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -13,40 +13,42 @@ provisioner:
   chef_license: accept-no-persist
 
 platforms:
-  - name: debian-9
+  - name: almalinux-8
     driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
+      pid_one_command: /bin/systemd
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,6 @@ driver:
 
 provisioner:
   name: chef_solo
-  product_name: chef
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
@@ -16,10 +15,12 @@ verifier:
     - path: test/integration/inspec
 
 platforms:
+  - name: almalinux-8
   - name: centos-7
-  - name: centos-8
-  - name: debian-9
+  - name: centos-stream-8
   - name: debian-10
+  - name: debian-11
+  - name: rockylinux-8
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 
@@ -37,8 +38,11 @@ suites:
       inputs:
         version: '5.6'
     excludes:
-      - centos-8
+      - almalinux-8
+      - centos-stream-8
       - debian-10
+      - debian-11
+      - rockylinux-8
       - ubuntu-20.04
 
   - name: client-57
@@ -83,8 +87,11 @@ suites:
         version: '5.6'
         devel: true
     excludes:
-      - centos-8
+      - almalinux-8
+      - centos-stream-8
       - debian-10
+      - debian-11
+      - rockylinux-8
       - ubuntu-20.04
 
   - name: devel-57
@@ -126,8 +133,11 @@ suites:
       percona:
         version: '5.6'
     excludes:
-      - centos-8
+      - almalinux-8
+      - centos-stream-8
       - debian-10
+      - debian-11
+      - rockylinux-8
       - ubuntu-20.04
     verifier:
       controls:
@@ -169,8 +179,11 @@ suites:
       percona:
         version: '5.6'
     excludes:
-      - centos-8
+      - almalinux-8
+      - centos-stream-8
       - debian-10
+      - debian-11
+      - rockylinux-8
       - ubuntu-20.04
     verifier:
       controls:
@@ -215,8 +228,11 @@ suites:
       percona:
         version: '5.6'
     excludes:
-      - centos-8
+      - almalinux-8
+      - centos-stream-8
       - debian-10
+      - debian-11
+      - rockylinux-8
       - ubuntu-20.04
     verifier:
       controls:
@@ -261,8 +277,11 @@ suites:
       percona:
         version: '5.6'
     excludes:
-      - centos-8
+      - almalinux-8
+      - centos-stream-8
       - debian-10
+      - debian-11
+      - rockylinux-8
       - ubuntu-20.04
     verifier:
       controls:
@@ -307,8 +326,11 @@ suites:
       percona:
         version: '5.6'
     excludes:
-      - centos-8
+      - almalinux-8
+      - centos-stream-8
       - debian-10
+      - debian-11
+      - rockylinux-8
       - ubuntu-20.04
     verifier:
       controls:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -103,7 +103,7 @@ module Percona
           node['platform_version'].to_i >= 10 ? 'libjemalloc2' : 'libjemalloc1'
         when 'ubuntu'
           node['platform_version'].to_f >= 20.04 ? 'libjemalloc2' : 'libjemalloc1'
-        when 'centos', 'redhat'
+        when 'centos', 'redhat', 'almalinux', 'rocky'
           'jemalloc'
         end
       end
@@ -114,8 +114,16 @@ module Percona
           node['platform_version'].to_i >= 10 ? '/usr/lib/x86_64-linux-gnu/libjemalloc.so.2' : '/usr/lib/x86_64-linux-gnu/libjemalloc.so.1'
         when 'ubuntu'
           node['platform_version'].to_f >= 20.04 ? '/usr/lib/x86_64-linux-gnu/libjemalloc.so.2' : '/usr/lib/x86_64-linux-gnu/libjemalloc.so.1'
-        when 'centos', 'redhat'
+        when 'centos', 'redhat', 'almalinux', 'rocky'
           node['platform_version'].to_i >= 8 ? '/usr/lib64/libjemalloc.so.2' : '/usr/lib64/libjemalloc.so.1'
+        end
+      end
+
+      def percona_default_encoding
+        if node['percona']['version'].to_i >= 8
+          'utf8mb3'
+        else
+          'utf8'
         end
       end
 

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -154,7 +154,8 @@ template percona['main_config_file'] do
   group 'root'
   mode '0644'
   sensitive true
-  manage_symlink_source true
+  manage_symlink_source false
+  force_unlink true
   variables(
     jemalloc_lib: percona_jemalloc_lib,
     wsrep_sst_auth: wsrep_sst_auth

--- a/resources/mysql_database.rb
+++ b/resources/mysql_database.rb
@@ -26,7 +26,7 @@ property :port,          [Integer, nil], default: 3306, desired_state: false
 property :user,          [String, nil],  default: 'root', desired_state: false
 property :socket,        [String, nil], desired_state: false
 property :password,      [String, nil], sensitive: true, desired_state: false
-property :encoding,      String,         default: 'utf8'
+property :encoding,      String,         default: lazy { percona_default_encoding }
 property :collation,     String,         default: 'utf8_general_ci'
 property :sql,           String
 

--- a/spec/configure_server_spec.rb
+++ b/spec/configure_server_spec.rb
@@ -34,7 +34,8 @@ describe 'percona::configure_server' do
         mode: '0644',
         cookbook: 'percona',
         source: 'my.cnf.main.erb',
-        manage_symlink_source: true
+        manage_symlink_source: false,
+        force_unlink: true
       )
 
       expect(chef_run).to render_file('/etc/mysql/my.cnf').with_content(
@@ -255,16 +256,16 @@ describe 'percona::configure_server' do
         )
       end
     end
-    context 'Debian 9' do
-      platform 'debian', '9'
+    context 'Debian 11' do
+      platform 'debian', '11'
 
       it do
-        expect(chef_run).to install_package 'libjemalloc1'
+        expect(chef_run).to install_package 'libjemalloc2'
       end
 
       it 'sets the correct malloc-lib path' do
         expect(chef_run).to render_file('/etc/mysql/my.cnf').with_content(
-          %r{^malloc-lib.*= /usr/lib/x86_64-linux-gnu/libjemalloc.so.1}
+          %r{^malloc-lib.*= /usr/lib/x86_64-linux-gnu/libjemalloc.so.2}
         )
       end
     end

--- a/templates/my.cnf.cluster.erb
+++ b/templates/my.cnf.cluster.erb
@@ -450,13 +450,13 @@ myisam_sort_buffer_size = <%= node["percona"]["server"]["myisam_sort_buffer_size
 # If the file-size would be bigger than this, the index will be created
 # through the key cache (which is slower).
 myisam_max_sort_file_size = <%= node["percona"]["server"]["myisam_max_sort_file_size"] %>
+<%- if node["percona"]["version"].to_f < 5.7 %>
 
 # If a table has more than one index, MyISAM can use more than one
 # thread to repair them by sorting in parallel. This makes sense if you
 # have multiple CPUs and plenty of memory.
 myisam_repair_threads = <%= node["percona"]["server"]["myisam_repair_threads"] %>
 
-<%- if node["percona"]["version"].to_f < 5.7 %>
 # Automatically check and repair not properly closed MyISAM tables.
 <% if node["percona"]["server"]["myisam_recover_options"] %>
 myisam_recover

--- a/templates/my.cnf.main.erb
+++ b/templates/my.cnf.main.erb
@@ -471,13 +471,13 @@ read_buffer_size = <%= node["percona"]["server"]["read_buffer_size"] %>
 # If the file-size would be bigger than this, the index will be created
 # through the key cache (which is slower).
 myisam_max_sort_file_size = <%= node["percona"]["server"]["myisam_max_sort_file_size"] %>
+<%- if node["percona"]["version"].to_f < 5.7 %>
 
 # If a table has more than one index, MyISAM can use more than one
 # thread to repair them by sorting in parallel. This makes sense if you
 # have multiple CPUs and plenty of memory.
 myisam_repair_threads = <%= node["percona"]["server"]["myisam_repair_threads"] %>
 
-<%- if node["percona"]["version"].to_f < 5.7 %>
 # Automatically check and repair not properly closed MyISAM tables.
 <% if node["percona"]["server"]["myisam_recover_options"] %>
 myisam_recover

--- a/test/fixtures/cookbooks/test/recipes/_remove_mysql_common.rb
+++ b/test/fixtures/cookbooks/test/recipes/_remove_mysql_common.rb
@@ -1,0 +1,11 @@
+# mailutils pulls in mysql-common which breaks initial installation on dokken based images. This doesn't seem to happen
+# in a non-container system so let's have this here for now
+if platform_family?('debian')
+  execute 'remove mysql-common' do
+    command <<~EOF
+      apt-get -y remove mailutils mailutils-common
+      apt-get -y autoremove
+    EOF
+    only_if { ::File.exist?('/usr/share/doc/mailutils-common/copyright') }
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/cluster.rb
+++ b/test/fixtures/cookbooks/test/recipes/cluster.rb
@@ -7,4 +7,5 @@ node.default['percona']['backup']['password'] = 'I}=sJ2bS'
 # Install postfix on RHEL to ensure we don't properly break mysql-libs compatibility
 package 'postfix' if platform_family?('rhel')
 
+include_recipe 'test::_remove_mysql_common'
 include_recipe 'percona::cluster'

--- a/test/fixtures/cookbooks/test/recipes/server.rb
+++ b/test/fixtures/cookbooks/test/recipes/server.rb
@@ -7,5 +7,6 @@ node.default['percona']['backup']['password'] = 'I}=sJ2bS'
 # Install postfix on RHEL to ensure we don't properly break mysql-libs compatibility
 package 'postfix' if platform_family?('rhel')
 
+include_recipe 'test::_remove_mysql_common'
 include_recipe 'percona::server'
 include_recipe 'percona::backup'

--- a/test/fixtures/cookbooks/test/recipes/user_database.rb
+++ b/test/fixtures/cookbooks/test/recipes/user_database.rb
@@ -3,6 +3,7 @@
 node.default['percona']['skip_passwords'] = true
 node.default['percona']['server']['debian_username'] = 'root'
 node.default['percona']['server']['debian_password'] = ''
+include_recipe 'test::_remove_mysql_common'
 include_recipe 'percona::server'
 
 # Create a schema to test mysql_database :drop against


### PR DESCRIPTION
- https://docs.percona.com/percona-server/5.7/release-notes/Percona-Server-5.7.39-42.html#deprecation-and-removal
- https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_myisam_repair_threads

In addition:

- Remove delivery and move to calling RSpec directly via a reusable workflow
- Update tested platforms
- Add support to Alma Linux & Rocky Linux
- Update default encoding when using 8.0 to `utf8mb3` to fix idempotency issues
- Fix management of server `my.cnf`
  - Set `manage_symlink_source` to `false` and set `force_unlink` to `true` to fix idempotency on Debian based systems
- Fix issue when testing on Debian dokken images by removing mailutils (and thus mysql-common)

Signed-off-by: Lance Albertson <lance@osuosl.org>
