### PR TITLE
Fastrobot/fix ctrl hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the percona cookbook.
 
 ## Unreleased
 
+- Fixed the user key in the ctrl_hash for the run_query method in the mysql_user custom resource
+
 ## 3.2.5 - *2023-03-15*
 
 Standardise files with files in sous-chefs/repo-management

--- a/resources/mysql_user.rb
+++ b/resources/mysql_user.rb
@@ -67,7 +67,7 @@ action_class do
 
   def run_query(query)
     socket = new_resource.ctrl_host == 'localhost' ? default_socket : nil
-    ctrl_hash = { host: new_resource.ctrl_host, port: new_resource.ctrl_port, username: new_resource.ctrl_user, password: new_resource.ctrl_password, socket: socket }
+    ctrl_hash = { host: new_resource.ctrl_host, port: new_resource.ctrl_port, user: new_resource.ctrl_user, password: new_resource.ctrl_password, socket: socket }
     Chef::Log.debug("#{@new_resource}: Performing query [#{query}]")
     execute_sql(query, nil, ctrl_hash)
   end

--- a/test/fixtures/cookbooks/test/recipes/user_database.rb
+++ b/test/fixtures/cookbooks/test/recipes/user_database.rb
@@ -66,6 +66,16 @@ bash 'create rizzo' do
   action :run
 end
 
+# Create a user to test ctrl_user, ctrl_password, and ctrl_host
+bash 'create beauregard' do
+  code <<-EOF
+  echo "CREATE USER 'beauregard'@'localhost' IDENTIFIED BY 'mupp3ts'; GRANT ALL PRIVILEGES ON *.* TO 'beauregard'@'localhost' WITH GRANT OPTION; FLUSH PRIVILEGES;" | /usr/bin/mysql -u root;
+  touch /tmp/beauregardmarker
+  EOF
+  not_if { ::File.exist?('/tmp/beauregardmarker') }
+  action :run
+end
+
 ## Resources we're testing
 percona_mysql_database 'databass' do
   action :create
@@ -168,6 +178,18 @@ percona_mysql_user 'beaker' do
   ctrl_password ''
   use_native_auth false
   action :create
+end
+
+# Create new user non-root user beauregard to test ctrl_hash
+percona_mysql_user 'bunsen' do
+  database_name 'datasalmon'
+  password 'honeydont'
+  ctrl_user 'beauregard'
+  ctrl_password 'mupp3ts'
+  ctrl_host '127.0.0.1'
+  host 'localhost'
+  privileges [:select]
+  action [:create, :grant]
 end
 
 percona_mysql_database 'flush privileges' do

--- a/test/integration/inspec/controls/resources_spec.rb
+++ b/test/integration/inspec/controls/resources_spec.rb
@@ -53,4 +53,8 @@ control 'percona_user' do
   describe sql.query("SELECT #{password_column} FROM mysql.user WHERE user='rizzo' AND host='127.0.0.1'") do
     its(:stdout) { should include '*125EA03B506F7C876D9321E9055F37601461E970' }
   end
+
+  describe sql.query('select User,Host from mysql.user') do
+    its(:stdout) { should match(/bunsen/) }
+  end
 end


### PR DESCRIPTION
# Description

Shortened 'username' to 'user' in the ctrl_hash for run_query method in the mysql_user custom resource
Added inspec test to verify non-root users passed in the ctrl_hash can successfully run percona_mysql_user

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ x ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
