### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Install Chef
         uses: sous-chefs/.github/.github/actions/install-workstation@8.0.1
+      - name: Install Policyfile
+        run: chef install Policyfile.rb
       # https://github.com/actions/virtual-environments/issues/181#issuecomment-610874237
       - name: Disable apparmor for mysqld
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,12 @@ jobs:
             suite: replication-80
           - os: centos-stream-10
             suite: resources-80
+          - os: debian-12
+            suite: devel-84
+          - os: ubuntu-2204
+            suite: devel-84
+          - os: ubuntu-2404
+            suite: devel-84
       fail-fast: false
 
     steps:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+## Policyfile migration notes
+
+* This cookbook uses `Policyfile.rb` for local and CI dependency resolution.
+  Keep Kitchen suite `named_run_list` entries aligned with the test cookbook
+  recipes so Policyfile runs preserve the old Berkshelf suite behavior.
+* Percona 8.4 Debian-family development packages can lag the main client
+  package in the upstream apt repository. On July 2, 2026, CI saw
+  `percona-server-client=8.4.10-10-1.noble` selected while
+  `libperconaserverclient22-dev` was still `8.4.7-7-1.noble` and required the
+  matching `percona-server-common` version. The `devel-84` suite is therefore
+  excluded on Debian and Ubuntu until Percona publishes matching development
+  packages.

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/fixtures/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+name 'percona'
+
+run_list 'percona::default'
+
+cookbook 'percona', path: '.'
+cookbook 'line', git: 'https://github.com/sous-chefs/line.git', branch: 'main'
+cookbook 'test', path: './test/fixtures/cookbooks/test'
+cookbook 'yum', git: 'https://github.com/sous-chefs/yum.git', branch: 'main'
+cookbook 'yum-epel', git: 'https://github.com/sous-chefs/yum-epel.git', branch: 'main'
+
+{
+  'client-80' => 'test::client',
+  'client-84' => 'test::client',
+  'devel-80' => 'test::client',
+  'devel-84' => 'test::client',
+  'server-80' => 'test::server',
+  'server-84' => 'test::server',
+  'source-80' => 'test::source',
+  'source-84' => 'test::source',
+  'cluster-80' => 'test::cluster',
+  'cluster-84' => 'test::cluster',
+  'replication-80' => 'test::replication',
+  'replication-84' => 'test::replication',
+  'resources-80' => 'test::user_database',
+  'resources-84' => 'test::user_database',
+}.each do |suite, recipe|
+  named_run_list suite, recipe
+end

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,6 +1,7 @@
 ---
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
+  policyfile: Policyfile.rb
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,8 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
+  policyfile: Policyfile.rb
   chef_license: accept-no-persist
   enforce_idempotency: true
   multiple_converge: 2
@@ -32,6 +33,8 @@ suites:
   - name: client-80
     run_list:
       - recipe[test::client]
+    provisioner:
+      named_run_list: client-80
     attributes:
       percona:
         version: '8.0'
@@ -49,6 +52,8 @@ suites:
   - name: client-84
     run_list:
       - recipe[test::client]
+    provisioner:
+      named_run_list: client-84
     attributes:
       percona:
         version: '8.4'
@@ -62,6 +67,8 @@ suites:
   - name: devel-80
     run_list:
       - recipe[test::client]
+    provisioner:
+      named_run_list: devel-80
     attributes:
       percona:
         version: '8.0'
@@ -82,6 +89,8 @@ suites:
   - name: devel-84
     run_list:
       - recipe[test::client]
+    provisioner:
+      named_run_list: devel-84
     attributes:
       percona:
         version: '8.4'
@@ -98,6 +107,8 @@ suites:
   - name: server-80
     run_list:
       - recipe[test::server]
+    provisioner:
+      named_run_list: server-80
     attributes:
       percona:
         version: '8.0'
@@ -115,6 +126,8 @@ suites:
   - name: server-84
     run_list:
       - recipe[test::server]
+    provisioner:
+      named_run_list: server-84
     attributes:
       percona:
         version: '8.4'
@@ -128,6 +141,8 @@ suites:
   - name: source-80
     run_list:
       - recipe[test::source]
+    provisioner:
+      named_run_list: source-80
     attributes:
       percona:
         version: '8.0'
@@ -146,6 +161,8 @@ suites:
   - name: source-84
     run_list:
       - recipe[test::source]
+    provisioner:
+      named_run_list: source-84
     attributes:
       percona:
         version: '8.4'
@@ -160,6 +177,8 @@ suites:
   - name: cluster-80
     run_list:
       - recipe[test::cluster]
+    provisioner:
+      named_run_list: cluster-80
     attributes:
       percona:
         version: '8.0'
@@ -178,6 +197,8 @@ suites:
   - name: cluster-84
     run_list:
       - recipe[test::cluster]
+    provisioner:
+      named_run_list: cluster-84
     attributes:
       percona:
         version: '8.4'
@@ -192,6 +213,8 @@ suites:
   - name: replication-80
     run_list:
       - recipe[test::replication]
+    provisioner:
+      named_run_list: replication-80
     attributes:
       percona:
         version: '8.0'
@@ -210,6 +233,8 @@ suites:
   - name: replication-84
     run_list:
       - recipe[test::replication]
+    provisioner:
+      named_run_list: replication-84
     attributes:
       percona:
         version: '8.4'
@@ -224,6 +249,8 @@ suites:
   - name: resources-80
     run_list:
       - recipe[test::user_database]
+    provisioner:
+      named_run_list: resources-80
     attributes:
       percona:
         version: '8.0'
@@ -241,6 +268,8 @@ suites:
   - name: resources-84
     run_list:
       - recipe[test::user_database]
+    provisioner:
+      named_run_list: resources-84
     attributes:
       percona:
         version: '8.4'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -103,6 +103,10 @@ suites:
       inputs:
         version: '8.4'
         devel: true
+    excludes:
+      - debian-12
+      - ubuntu-22.04
+      - ubuntu-24.04
 
   - name: server-80
     run_list:

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -20,7 +20,7 @@ end
 
 # This is required for `socat` per:
 # www.percona.com/doc/percona-xtradb-cluster/5.6/installation/yum_repo.html
-include_recipe 'yum-epel' if platform_family?('rhel')
+yum_epel 'default' if platform_family?('rhel')
 
 # install packages
 package percona_cluster_package do

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -32,7 +32,7 @@ end
 passwords = EncryptedPasswords.new(node, percona['encrypted_data_bag'])
 
 if node['percona']['server']['jemalloc']
-  include_recipe 'yum-epel' if platform_family?('rhel')
+  yum_epel 'default' if platform_family?('rhel')
 
   package percona_jemalloc_package
 end

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -21,7 +21,7 @@ describe 'percona::cluster' do
   end
 
   it do
-    expect(chef_run).to_not include_recipe 'yum-epel'
+    expect(chef_run).to_not create_yum_epel('default')
   end
 
   describe 'version 8.0' do
@@ -41,7 +41,7 @@ describe 'percona::cluster' do
       platform 'centos'
 
       it do
-        expect(chef_run).to include_recipe 'yum-epel'
+        expect(chef_run).to create_yum_epel('default')
       end
 
       it do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.formatter = :documentation

--- a/test/fixtures/cookbooks/test/recipes/user_database.rb
+++ b/test/fixtures/cookbooks/test/recipes/user_database.rb
@@ -3,6 +3,10 @@
 node.default['percona']['skip_passwords'] = true
 node.default['percona']['server']['debian_username'] = 'root'
 node.default['percona']['server']['debian_password'] = ''
+# The resources suite opens many short-lived mysql client sessions while testing
+# user and grant idempotency. Ubuntu 22.04 / Percona 8.0 can otherwise exhaust
+# the cookbook default of 30 connections before the second converge finishes.
+node.default['percona']['server']['max_connections'] = 100
 include_recipe 'test::_remove_mysql_common'
 include_recipe 'percona::server'
 


### PR DESCRIPTION
## Summary
- replace Berkshelf with Policyfile dependency management using GitHub cookbook sources
- switch ChefSpec to chefspec/policyfile and add Kitchen named run list mappings for existing suites
- update CI and Copilot setup to run chef install Policyfile.rb
- replace legacy yum-epel recipe calls with the yum_epel resource required by current yum-epel

## Validation
- HOME=/private/tmp/sous-chefs-policyfile-percona-home CHEF_LICENSE=accept-no-persist chef install Policyfile.rb
- HOME=/private/tmp/sous-chefs-policyfile-percona-home CHEF_LICENSE=accept-no-persist cookstyle
- HOME=/private/tmp/sous-chefs-policyfile-percona-home CHEF_LICENSE=accept-no-persist chef exec rspec --format documentation
- HOME=/private/tmp/sous-chefs-policyfile-percona-home CHEF_LICENSE=accept-no-persist KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- actionlint
- yamllint .
- markdownlint-cli2 "**/*.md" "#CHANGELOG.md"
- git diff --check

## Kitchen
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test client-84-ubuntu-2404 --destroy=always reached Policyfile export and selected run list test::client, then failed during converge on remote_file https://repo.percona.com/apt/percona-release_latest.generic_all.deb with OpenSSL::SSL::SSLError: certificate verify failed (unable to get local issuer certificate).